### PR TITLE
Implement Save and Save As

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,17 +5,6 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "(Windows) LLDB",
-      "type": "lldb",
-      "request": "launch",
-      "program": "${workspaceRoot}/target/debug/xi-win.exe",
-      "args": [],
-      "cwd": "${workspaceRoot}",
-      "sourceLanguages": [
-        "rust"
-      ]
-    },
-    {
       "name": "(Windows) MSVC",
       "type": "cppvsdbg",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "(Windows) LLDB",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${workspaceRoot}/target/debug/xi-win.exe",
+      "args": [],
+      "cwd": "${workspaceRoot}",
+      "sourceLanguages": [
+        "rust"
+      ]
+    },
+    {
+      "name": "(Windows) MSVC",
+      "type": "cppvsdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/target/debug/xi-win.exe",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": true
+    }
+  ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,22 +1,3 @@
-[root]
-name = "xi-win"
-version = "0.1.0"
-dependencies = [
- "direct2d 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "directwrite 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "xi-core-lib 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "xi-rpc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "bytecount"
 version = "0.1.6"
@@ -222,6 +203,25 @@ dependencies = [
 name = "xi-unicode"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "xi-win"
+version = "0.1.0"
+dependencies = [
+ "direct2d 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "directwrite 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xi-core-lib 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xi-rpc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [metadata]
 "checksum bytecount 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1e8f09fbc8c6726a4b616dcfbd4f54491068d6bb1b93ac03c78ac18ff9a5924a"

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -1,0 +1,46 @@
+extern crate ole32;
+extern crate uuid;
+extern crate winapi;
+
+use winapi::*;
+use std::ptr::null_mut;
+use util::{FromWide};
+
+pub unsafe fn get_open_file_dialog_path(hwnd_owner: HWND) -> Option<String> {
+  get_file_dialog_path(hwnd_owner, true)
+}
+
+pub unsafe fn get_save_file_dialog_path(hwnd_owner: HWND) -> Option<String> {
+  get_file_dialog_path(hwnd_owner, false)
+}
+
+unsafe fn get_file_dialog_path(hwnd_owner: HWND, open: bool) -> Option<String> {
+  let mut filename: Option<String> = None;
+  let mut pfd: *mut IFileDialog = null_mut();
+  let class = if open { &uuid::CLSID_FileOpenDialog } else { &uuid::CLSID_FileSaveDialog };
+  let id = if open { &uuid::IID_IFileOpenDialog } else { &uuid::IID_IFileSaveDialog };
+  let hr = ole32::CoCreateInstance(class,
+      null_mut(),
+      winapi::CLSCTX_INPROC_SERVER,
+      id,
+      &mut pfd as *mut *mut winapi::IFileDialog as *mut winapi::LPVOID
+      );
+  if hr != winapi::S_OK {
+      return None; // TODO: should be error result
+  }
+  (*pfd).Show(hwnd_owner);
+  let mut result: *mut winapi::IShellItem = null_mut();
+  (*pfd).GetResult(&mut result);
+  if !result.is_null() {
+      let mut display_name: LPWSTR = null_mut();
+      (*result).GetDisplayName(SIGDN_FILESYSPATH, &mut display_name);
+      filename = display_name.from_wide();
+      ole32::CoTaskMemFree(display_name as LPVOID);
+      (*result).Release();
+  } else {
+      //println!("result is null");
+  }
+  (*pfd).Release();
+
+  filename
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ use hwnd_rt::HwndRtParams;
 use linecache::LineCache;
 use menus::Menus;
 use util::{Error, ToWide, OptionalFunctions};
-use window::{create_window, set_menu, WndProc};
+use window::{create_window, WndProc};
 use dialog::{get_open_file_dialog_path, get_save_file_dialog_path};
 use xi_thread::{start_xi_thread, XiPeer};
 
@@ -204,11 +204,6 @@ impl MainWin {
             self.send_edit_cmd("open", &json!({
                 "filename": filename,
             }));
-
-            // Update menu to enable the Save item now that a file is open.
-            let menus = Menus::create(true);
-            let hmenu = menus.get_hmenubar();
-            unsafe { set_menu(hwnd_owner, hmenu); }
         }
     }
 
@@ -231,11 +226,6 @@ impl MainWin {
             }));
 
             self.state.borrow_mut().filename = Some(filename.clone());
-
-            // Update menu to enable the Save item now that a file is open.
-            let menus = Menus::create(true);
-            let hmenu = menus.get_hmenubar();
-            unsafe { set_menu(hwnd_owner, hmenu); }
         }
     }
 }
@@ -415,7 +405,7 @@ fn create_main(optional_functions: &OptionalFunctions, xi_peer: XiPeer) -> Resul
         let width = (500.0 * (dpi/96.0)) as i32;
         let height = (400.0 * (dpi/96.0)) as i32;
 
-        let menus = Menus::create(false);
+        let menus = Menus::create();
         let hmenu = menus.get_hmenubar();
         let hwnd = create_window(winapi::WS_EX_OVERLAPPEDWINDOW, class_name.as_ptr(),
             class_name.as_ptr(), WS_OVERLAPPEDWINDOW | winapi::WS_VSCROLL,

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,6 @@ extern crate winapi;
 extern crate user32;
 extern crate gdi32;
 extern crate kernel32;
-extern crate ole32;
-extern crate uuid;
 extern crate direct2d;
 extern crate directwrite;
 
@@ -37,6 +35,7 @@ mod linecache;
 mod menus;
 mod util;
 mod window;
+mod dialog;
 mod xi_thread;
 
 use std::cell::RefCell;
@@ -58,8 +57,9 @@ use serde_json::Value;
 use hwnd_rt::HwndRtParams;
 use linecache::LineCache;
 use menus::Menus;
-use util::{Error, FromWide, ToWide, OptionalFunctions};
+use util::{Error, ToWide, OptionalFunctions};
 use window::{create_window, WndProc};
+use dialog::{get_open_file_dialog_path, get_save_file_dialog_path};
 use xi_thread::{start_xi_thread, XiPeer};
 
 struct Resources {
@@ -89,6 +89,7 @@ struct MainWinState {
     dwrite_factory: directwrite::Factory,
     render_target: Option<RenderTarget>,
     resources: Option<Resources>,
+    filename: Option<String>,
 }
 
 impl MainWinState {
@@ -102,6 +103,7 @@ impl MainWinState {
             dwrite_factory: directwrite::Factory::new().unwrap(),
             render_target: None,
             resources: None,
+            filename: None
         }
     }
 
@@ -194,36 +196,31 @@ impl MainWin {
     }
 
     fn file_open(&self, hwnd_owner: HWND) {
-        unsafe {
-            let mut pfd: *mut IFileDialog = null_mut();
-            let hr = ole32::CoCreateInstance(&uuid::CLSID_FileOpenDialog,
-                null_mut(),
-                winapi::CLSCTX_INPROC_SERVER,
-                &uuid::IID_IFileOpenDialog,
-                &mut pfd as *mut *mut winapi::IFileDialog as *mut winapi::LPVOID
-                );
-            if hr != winapi::S_OK {
-                return;  // TODO: should be error result
-            }
-            (*pfd).Show(hwnd_owner);
-            let mut result: *mut winapi::IShellItem = null_mut();
-            (*pfd).GetResult(&mut result);
-            if !result.is_null() {
-                let mut display_name: LPWSTR = null_mut();
-                (*result).GetDisplayName(SIGDN_FILESYSPATH, &mut display_name);
-                if let Some(filename) = display_name.from_wide() {
-                    // Note: this whole protocol has changed a lot since the
-                    // 0.2 version of xi-core.
-                    self.send_edit_cmd("open", &json!({
-                        "filename": filename,
-                    }));
-                }
-                ole32::CoTaskMemFree(display_name as LPVOID);
-                (*result).Release();
-            } else {
-                //println!("result is null");
-            }
-            (*pfd).Release();
+        let filename = unsafe { get_open_file_dialog_path(hwnd_owner) };
+        if let Some(filename) = filename {
+            // TODO: Do not save here and pull from Xi core based on `self.state.view_id` instead?
+            self.state.borrow_mut().filename = Some(filename.clone());
+            // Note: this whole protocol has changed a lot since the
+            // 0.2 version of xi-core.
+            self.send_edit_cmd("open", &json!({
+                "filename": filename,
+            }));
+        }
+    }
+
+    // TODO: Split this into `save` and `save_as`
+    fn file_save(&self, hwnd_owner: HWND) {
+        // TODO: Make this work instead of crashing with 101 exit code
+        // let filename = &self.state.borrow().filename;
+        // if let &Some(ref filename) = filename {
+        //     self.send_edit_cmd("save", &json!({
+        //         "filename": filename,
+        //     }));
+        // } else
+        if let Some(filename) = unsafe { get_save_file_dialog_path(hwnd_owner) } {
+            self.send_edit_cmd("save", &json!({
+                "filename": filename,
+            }));
         }
     }
 }
@@ -334,6 +331,9 @@ impl WndProc for MainWin {
                     }
                     x if x == menus::MenuEntries::Open as WPARAM => {
                         self.file_open(hwnd);
+                    }
+                    x if x == menus::MenuEntries::Save as WPARAM => {
+                        self.file_save(hwnd);
                     }
                     _ => return Some(1),
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,11 +208,11 @@ impl MainWin {
     }
 
     fn file_save(&self, hwnd_owner: HWND) {
-        let filename: &Option<String> = &self.state.borrow_mut().filename;
+        let filename: Option<String> = self.state.borrow_mut().filename.clone();
         if filename.is_none() {
             self.file_save_as(hwnd_owner);
         } else {
-            let filename: String = filename.clone().unwrap();
+            let filename = filename.unwrap();
             self.send_edit_cmd("save", &json!({
                 "filename": filename,
             }));

--- a/src/menus.rs
+++ b/src/menus.rs
@@ -24,6 +24,7 @@ pub enum MenuEntries {
     Exit = 0x100,
     Open,
     Save,
+    SaveAs,
 }
 
 pub struct Menus {
@@ -32,13 +33,16 @@ pub struct Menus {
 
 impl Menus {
     // TODO: wire up accelerators corresponding to the advertised keyboard shortcuts.
-    pub fn create() -> Menus {
+    pub fn create(save_enabled: bool) -> Menus {
         unsafe {
             let hmenubar = CreateMenu();
             let hmenu = CreateMenu();
             AppendMenuW(hmenubar, MF_POPUP, hmenu as UINT_PTR, "&File".to_wide().as_ptr());
-            AppendMenuW(hmenu, MF_STRING, MenuEntries::Open as UINT_PTR, "&Open\tCtrl+O".to_wide().as_ptr());
-            AppendMenuW(hmenu, MF_STRING, MenuEntries::Save as UINT_PTR, "&Save\tCtrl+S".to_wide().as_ptr());
+            AppendMenuW(hmenu, MF_STRING, MenuEntries::Open as UINT_PTR, "&Open…\tCtrl+O".to_wide().as_ptr());
+            AppendMenuW(hmenu, if save_enabled { MF_STRING } else { MF_STRING | MF_DISABLED },
+                MenuEntries::Save as UINT_PTR, "&Save\tCtrl+S".to_wide().as_ptr());
+            AppendMenuW(hmenu, MF_STRING,
+                MenuEntries::SaveAs as UINT_PTR, "&Save as…".to_wide().as_ptr());
             AppendMenuW(hmenu, MF_STRING, MenuEntries::Exit as UINT_PTR, "E&xit".to_wide().as_ptr());
 
             let hmenu = CreateMenu();

--- a/src/menus.rs
+++ b/src/menus.rs
@@ -33,16 +33,14 @@ pub struct Menus {
 
 impl Menus {
     // TODO: wire up accelerators corresponding to the advertised keyboard shortcuts.
-    pub fn create(save_enabled: bool) -> Menus {
+    pub fn create() -> Menus {
         unsafe {
             let hmenubar = CreateMenu();
             let hmenu = CreateMenu();
             AppendMenuW(hmenubar, MF_POPUP, hmenu as UINT_PTR, "&File".to_wide().as_ptr());
             AppendMenuW(hmenu, MF_STRING, MenuEntries::Open as UINT_PTR, "&Open…\tCtrl+O".to_wide().as_ptr());
-            AppendMenuW(hmenu, if save_enabled { MF_STRING } else { MF_STRING | MF_DISABLED },
-                MenuEntries::Save as UINT_PTR, "&Save\tCtrl+S".to_wide().as_ptr());
-            AppendMenuW(hmenu, MF_STRING,
-                MenuEntries::SaveAs as UINT_PTR, "&Save as…".to_wide().as_ptr());
+            AppendMenuW(hmenu, MF_STRING, MenuEntries::Save as UINT_PTR, "&Save\tCtrl+S".to_wide().as_ptr());
+            AppendMenuW(hmenu, MF_STRING, MenuEntries::SaveAs as UINT_PTR, "&Save as…".to_wide().as_ptr());
             AppendMenuW(hmenu, MF_STRING, MenuEntries::Exit as UINT_PTR, "E&xit".to_wide().as_ptr());
 
             let hmenu = CreateMenu();

--- a/src/menus.rs
+++ b/src/menus.rs
@@ -23,6 +23,7 @@ use util::ToWide;
 pub enum MenuEntries {
     Exit = 0x100,
     Open,
+    Save,
 }
 
 pub struct Menus {
@@ -37,6 +38,7 @@ impl Menus {
             let hmenu = CreateMenu();
             AppendMenuW(hmenubar, MF_POPUP, hmenu as UINT_PTR, "&File".to_wide().as_ptr());
             AppendMenuW(hmenu, MF_STRING, MenuEntries::Open as UINT_PTR, "&Open\tCtrl+O".to_wide().as_ptr());
+            AppendMenuW(hmenu, MF_STRING, MenuEntries::Save as UINT_PTR, "&Save\tCtrl+S".to_wide().as_ptr());
             AppendMenuW(hmenu, MF_STRING, MenuEntries::Exit as UINT_PTR, "E&xit".to_wide().as_ptr());
 
             let hmenu = CreateMenu();

--- a/src/window.rs
+++ b/src/window.rs
@@ -74,13 +74,6 @@ pub unsafe fn create_window(
     hwnd
 }
 
-// https://msdn.microsoft.com/en-us/library/windows/desktop/ms647995(v=vs.85).aspx
-// https://github.com/retep998/winapi-rs/blob/0.3/src/um/winuser.rs#L3718
-#[allow(non_snake_case)]
-pub unsafe fn set_menu(hWnd: HWND, hMenu: HMENU) -> HMENU {
-    SetMenu(hWnd, hMenu)
-}
-
 #[allow(non_snake_case)]
 #[allow(unused)]
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms645505(v=vs.85).aspx

--- a/src/window.rs
+++ b/src/window.rs
@@ -22,6 +22,8 @@ use serde_json::Value;
 use std::mem;
 use std::rc::Rc;
 
+use util::{ToWide};
+
 pub trait WndProc {
     fn window_proc(&self, hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> Option<LRESULT>;
 
@@ -70,4 +72,20 @@ pub unsafe fn create_window(
     let hwnd = CreateWindowExW(dwExStyle, lpClassName, lpWindowName, dwStyle, x, y,
         nWidth, nHeight, hWndParent, hMenu, hInstance, Rc::into_raw(wndproc) as LPVOID);
     hwnd
+}
+
+// https://msdn.microsoft.com/en-us/library/windows/desktop/ms647995(v=vs.85).aspx
+// https://github.com/retep998/winapi-rs/blob/0.3/src/um/winuser.rs#L3718
+#[allow(non_snake_case)]
+pub unsafe fn set_menu(hWnd: HWND, hMenu: HMENU) -> HMENU {
+    SetMenu(hWnd, hMenu)
+}
+
+#[allow(non_snake_case)]
+#[allow(unused)]
+// https://msdn.microsoft.com/en-us/library/windows/desktop/ms645505(v=vs.85).aspx
+// https://github.com/retep998/winapi-rs/blob/0.3/src/um/winuser.rs#L4652
+pub unsafe fn message_box(hWnd: HWND, text: String) -> c_int {
+    let text = text.to_wide().as_ptr();
+    MessageBoxW(hWnd, text, "Xi".to_wide().as_ptr(), MB_OK)
 }


### PR DESCRIPTION
Hello, I'd like to start trying to contribute to this Windows API based frontend. I am a novice to both Rust and Windows API (I do have experience with interoping with it from .NET so it shouldn't be too bad), so if you prefer my experiments stick to my fork, I will totally understand that.

In this PR I have introduced a *Save* menu item. Currently it behaves as a *Save as…* because I was not able to make pulling out the `filename` from the `state` work yet. I will keep trying (and figure out how to use a debugger etc.), so I opened the PR already in case it would be okay to do that in two PRs, otherwise I'll push the fix to this PR as well.