### PR TITLE
Add idle handler and animation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,7 @@ dependencies = [
  "direct2d 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/xi-win-shell/Cargo.lock
+++ b/xi-win-shell/Cargo.lock
@@ -23,6 +23,26 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libc"
+version = "0.2.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "time"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +76,7 @@ dependencies = [
  "direct2d 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "directwrite 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -63,6 +84,9 @@ dependencies = [
 "checksum direct2d 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e3900cd45f7b9c723188d52f0801af1aef748dea91d8df544e07ebb5059883c7"
 "checksum directwrite 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "cacb08d14cfd2ee00c770be606aef1b737db61ca6ea8d6a3a30536b040ec502c"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/xi-win-shell/Cargo.toml
+++ b/xi-win-shell/Cargo.toml
@@ -10,6 +10,7 @@ directwrite = "0.0.9"
 direct2d = "0.0.9"
 
 lazy_static = "1.0"
+time = "0.1.39"
 
 [dependencies.winapi]
 version = "0.3"

--- a/xi-win-shell/examples/hello.rs
+++ b/xi-win-shell/examples/hello.rs
@@ -21,7 +21,6 @@ use direct2d::math::*;
 
 use xi_win_shell::menu::Menu;
 use xi_win_shell::paint::PaintCtx;
-use xi_win_shell::util;
 use xi_win_shell::win_main;
 use xi_win_shell::window::{WindowBuilder, WindowHandle, WinHandler};
 
@@ -35,7 +34,7 @@ impl WinHandler for HelloState {
         *self.handle.borrow_mut() = handle.clone();
     }
 
-    fn paint(&self, paint_ctx: &mut PaintCtx) {
+    fn paint(&self, paint_ctx: &mut PaintCtx) -> bool {
         let rt = paint_ctx.render_target();
         let size = rt.get_size();
         let rect = RectF::from((0.0, 0.0, size.width, size.height));
@@ -46,6 +45,7 @@ impl WinHandler for HelloState {
             &BrushProperties::default()).unwrap();
         rt.draw_line(&Point2F::from((10.0, 50.0)), &Point2F::from((90.0, 90.0)),
                 &fg, 1.0, None);
+        false
     }
 
     fn command(&self, id: u32) {
@@ -76,12 +76,12 @@ fn main() {
     let mut menubar = Menu::new();
     menubar.add_dropdown(file_menu, "&File");
 
-    let mut builder = WindowBuilder::new();
+    let mut run_loop = win_main::RunLoop::new();
+    let mut builder = WindowBuilder::new(run_loop.get_handle());
     builder.set_handler(Box::new(HelloState::default()));
     builder.set_title("Hello example");
     builder.set_menu(menubar);
     let window = builder.build().unwrap();
     window.show();
-    let mut run_loop = win_main::RunLoop::new();
     run_loop.run();
 }

--- a/xi-win-shell/examples/perftest.rs
+++ b/xi-win-shell/examples/perftest.rs
@@ -1,0 +1,138 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate xi_win_shell;
+extern crate direct2d;
+extern crate directwrite;
+extern crate time;
+
+use std::cell::RefCell;
+
+use time::get_time;
+
+use direct2d::math::*;
+use direct2d::render_target::DrawTextOption;
+use directwrite::text_format;
+
+use xi_win_shell::paint::PaintCtx;
+use xi_win_shell::win_main;
+use xi_win_shell::window::{WindowBuilder, WindowHandle, WinHandler};
+
+struct PerfTest(RefCell<PerfState>);
+
+struct PerfState {
+    handle: WindowHandle,
+    last_time: f64,
+    dwrite_factory: directwrite::Factory,
+}
+
+impl WinHandler for PerfTest {
+    fn connect(&self, handle: &WindowHandle) {
+        self.0.borrow_mut().handle = handle.clone();
+    }
+
+    fn paint(&self, paint_ctx: &mut PaintCtx) -> bool {
+        let mut state = self.0.borrow_mut();
+        let rt = paint_ctx.render_target();
+        let size = rt.get_size();
+        let rect = RectF::from((0.0, 0.0, size.width, size.height));
+        let bg = rt.create_solid_color_brush(0x272822,
+            &BrushProperties::default()).unwrap();
+        rt.fill_rectangle(&rect, &bg);
+        let fg = rt.create_solid_color_brush(0xf0f0ea,
+            &BrushProperties::default()).unwrap();
+
+        rt.draw_line(&Point2F::from((0.0, size.height)),
+            &Point2F::from((size.width, 0.0)),
+            &fg, 1.0, None);
+
+        let th = ::std::f32::consts::PI * (get_time().nsec as f32) * 2e-9;
+        let dx = 100.0 * th.sin();
+        let dy = 100.0 * th.cos();
+        rt.draw_line(&Point2F::from((100.0, 100.0)),
+            &Point2F::from((100.0 + dx, 100.0 - dy)),
+            &fg, 1.0, None);
+
+        let text_format_params = text_format::ParamBuilder::new()
+            .size(15.0)
+            .family("Consolas")
+            .build().unwrap();
+        let text_format = state.dwrite_factory.create(text_format_params).unwrap();
+
+        let now = get_time();
+        let now = now.sec as f64 + 1e-9 * now.nsec as f64;
+        let msg = format!("{:3.1}ms", 1e3 * (now - state.last_time));
+        state.last_time = now;
+        rt.draw_text(
+            &msg,
+            &text_format,
+            &RectF::from((10.0, 210.0, 100.0, 300.0)),
+            &fg,
+            &[DrawTextOption::EnableColorFont]
+        );
+
+        let msg = "Hello DWrite! This is a somewhat longer string of text intended to provoke slightly longer draw times.";
+        let dy = 15.0;
+        let x0 = 210.0;
+        let y0 = 10.0;
+        for i in 0..60 {
+            let y = y0 + (i as f32) * dy;
+            rt.draw_text(
+                msg,
+                &text_format,
+                &RectF::from((x0, y, x0 + 900.0, y + 80.0)),
+                &fg,
+                &[DrawTextOption::EnableColorFont]
+            );
+        }
+
+    true
+    }
+
+    fn command(&self, id: u32) {
+        match id {
+            0x100 => self.0.borrow().handle.close(),
+            _ => println!("unexpected id {}", id),
+        }
+    }
+
+    fn char(&self, ch: u32) {
+        println!("got char 0x{:x}", ch);
+    }
+
+    fn keydown(&self, vk_code: i32) {
+        println!("got key code 0x{:x}", vk_code);
+    }
+
+    fn destroy(&self) {
+        win_main::request_quit();
+    }
+}
+
+fn main() {
+    xi_win_shell::init();
+
+    let mut run_loop = win_main::RunLoop::new();
+    let mut builder = WindowBuilder::new(run_loop.get_handle());
+    let perf_state = PerfState {
+        dwrite_factory: directwrite::Factory::new().unwrap(),
+        handle: Default::default(),
+        last_time: 0.0,
+    };
+    builder.set_handler(Box::new(PerfTest(RefCell::new(perf_state))));
+    builder.set_title("Performance tester");
+    let window = builder.build().unwrap();
+    window.show();
+    run_loop.run();
+}


### PR DESCRIPTION
Adds an idle handler and the ability to play an animation.

Putting the idle handler in the mainloop is probably not ideal, as it
doesn't get called when another mainloop is active (seems to happen
on window resize, and will certainly happen for dialogs).

Window sizing dynamics are reasonably good, but animation shows a
diagonal tearing artifact on the laptop screen on my hardware
(Gigabyte Aero 14 with NVidia 1060).