### PR TITLE
Rollup of work in progress: kinda working scrolling

### DIFF
--- a/src/edit_view.rs
+++ b/src/edit_view.rs
@@ -1,0 +1,175 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The main edit view.
+
+use serde_json::Value;
+
+use winapi::um::winuser::*;
+
+use direct2d::brush;
+use direct2d::math::*;
+use directwrite::{self, TextFormat, TextLayout};
+use directwrite::text_format;
+use directwrite::text_layout;
+
+use xi_win_shell::paint::PaintCtx;
+use xi_win_shell::util::default_text_options;
+
+use MainWin;
+
+use linecache::LineCache;
+
+/// State and behavior for one editor view.
+pub struct EditView {
+    // Note: these public fields should be properly encapsulated.
+    pub view_id: String,
+    pub filename: Option<String>,
+    line_cache: LineCache,
+    dwrite_factory: directwrite::Factory,
+    resources: Option<Resources>,
+}
+
+struct Resources {
+    fg: brush::SolidColor,
+    bg: brush::SolidColor,
+    text_format: TextFormat,
+}
+
+impl EditView {
+    pub fn new() -> EditView {
+        EditView {
+            view_id: "".into(),
+            filename: None,
+            line_cache: LineCache::new(),
+            dwrite_factory: directwrite::Factory::new().unwrap(),
+            resources: None,
+        }
+    }
+
+    fn create_resources(&mut self, p: &mut PaintCtx) -> Resources {
+        let rt = p.render_target();
+        let text_format_params = text_format::ParamBuilder::new()
+            .size(15.0)
+            .family("Consolas")
+            .build().unwrap();
+        let text_format = self.dwrite_factory.create(text_format_params).unwrap();
+        Resources {
+            fg: rt.create_solid_color_brush(0xf0f0ea, &BrushProperties::default()).unwrap(),
+            bg: rt.create_solid_color_brush(0x272822, &BrushProperties::default()).unwrap(),
+            text_format: text_format,
+        }
+    }
+
+    pub fn clear_line_cache(&mut self) {
+        self.line_cache = LineCache::new();
+    }
+
+    pub fn render(&mut self, p: &mut PaintCtx) {
+        if self.resources.is_none() {
+            self.resources = Some(self.create_resources(p));
+        }
+        let resources = &self.resources.as_ref().unwrap();
+        let rt = p.render_target();
+        let size = rt.get_size();
+        let rect = RectF::from((0.0, 0.0, size.width, size.height));
+        rt.fill_rectangle(&rect, &resources.bg);
+
+        let x0 = 6.0;
+        let mut y = 6.0;
+        for line_num in 0..self.line_cache.height() {
+            if let Some(line) = self.line_cache.get_line(line_num) {
+                let layout = resources.create_text_layout(&self.dwrite_factory, line.text());
+                rt.draw_text_layout(
+                    &Point2F::from((x0, y)),
+                    &layout,
+                    &resources.fg,
+                    default_text_options()
+                );
+                for &offset in line.cursor() {
+                    if let Some(pos) = layout.hit_test_text_position(offset as u32, true) {
+                        let x = x0 + pos.point_x;
+                        rt.draw_line(&Point2F::from((x, y)),
+                            &Point2F::from((x, y + 17.0)),
+                            &resources.fg, 1.0, None);
+                    }
+                }
+            }
+            y += 17.0;
+        }
+    }
+
+    pub fn set_view_id(&mut self, view_id: &str) {
+        self.view_id = view_id.into();
+    }
+
+    pub fn apply_update(&mut self, update: &Value) {
+        self.line_cache.apply_update(update);
+    }
+
+    pub fn char(&self, ch: u32, _mods: u32, win: &MainWin) {
+        let view_id = &self.view_id;
+        match ch {
+            0x08 => {
+                win.send_edit_cmd("delete_backward", &json!([]), view_id);
+            },
+            0x0d => {
+                win.send_edit_cmd("insert_newline", &json!([]), view_id);
+            },
+            _ => {
+                if let Some(c) = ::std::char::from_u32(ch) {
+                    let params = json!({"chars": c.to_string()});
+                    win.send_edit_cmd("insert", &params, view_id);
+                }
+            }
+        }
+    }
+
+    pub fn keydown(&self, vk_code: i32, _mods: u32, win: &MainWin) -> bool {
+        let view_id = &self.view_id;
+        // Handle special keys here
+        match vk_code {
+            VK_UP => {
+                win.send_edit_cmd("move_up", &json!([]), view_id);
+            },
+            VK_DOWN => {
+                win.send_edit_cmd("move_down", &json!([]), view_id);
+            },
+            VK_LEFT => {
+                win.send_edit_cmd("move_left", &json!([]), view_id);
+            },
+            VK_RIGHT => {
+                win.send_edit_cmd("move_right", &json!([]), view_id);
+            },
+            VK_DELETE => {
+                win.send_edit_cmd("delete_forward", &json!([]), view_id);
+            },
+            _ => return false
+        }
+        true
+    }
+
+}
+
+impl Resources {
+    fn create_text_layout(&self, factory: &directwrite::Factory, text: &str) -> TextLayout {
+        let params = text_layout::ParamBuilder::new()
+            .text(text)
+            .font(self.text_format.clone())
+            .width(1e6)
+            .height(1e6)
+            .build().unwrap();
+        factory.create(params).unwrap()
+    }
+}

--- a/src/linecache.rs
+++ b/src/linecache.rs
@@ -80,7 +80,7 @@ impl LineCache {
                 for _ in 0..n {
                     let _ = old_iter.next();
                 }
-            } else if op_type == "inval" {
+            } else if op_type == "invalidate" {
                 let n = op["n"].as_u64().unwrap();
                 for _ in 0..n {
                     self.push_opt_line(None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,7 +277,7 @@ impl WinHandler for MainWinHandler {
         }
     }
 
-    fn char(&self, ch: u32) {
+    fn char(&self, ch: u32, _mods: u32) {
         match ch {
             0x08 => {
                 self.win.send_edit_cmd("delete_backward", &json!([]));
@@ -294,7 +294,7 @@ impl WinHandler for MainWinHandler {
         }
     }
 
-    fn keydown(&self, vk_code: i32) {
+    fn keydown(&self, vk_code: i32, _mods: u32) -> bool {
         // Handle special keys here
         match vk_code {
             VK_UP => {
@@ -312,8 +312,9 @@ impl WinHandler for MainWinHandler {
             VK_DELETE => {
                 self.win.send_edit_cmd("delete_forward", &json!([]));
             },
-            _ => ()
+            _ => return false
         }
+        true
     }
 
     fn destroy(&self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,9 +34,10 @@ extern crate xi_core_lib;
 extern crate xi_rpc;
 extern crate xi_win_shell;
 
+mod dialog;
+mod edit_view;
 mod linecache;
 mod menus;
-mod dialog;
 mod xi_thread;
 
 use std::cell::RefCell;
@@ -44,113 +45,36 @@ use std::sync::mpsc::TryRecvError;
 use std::rc::Rc;
 
 use winapi::shared::windef::*;
-use winapi::um::winuser::*;
-
-use direct2d::brush;
-use direct2d::math::*;
-use directwrite::text_format::{self, TextFormat};
-use directwrite::text_layout::{self, TextLayout};
 
 use serde_json::Value;
 
-use linecache::LineCache;
+use edit_view::EditView;
 use menus::MenuEntries;
 use xi_win_shell::util::Error;
 use dialog::{get_open_file_dialog_path, get_save_file_dialog_path};
 use xi_thread::{start_xi_thread, XiPeer};
 
 use xi_win_shell::paint::PaintCtx;
-use xi_win_shell::util::default_text_options;
 use xi_win_shell::win_main::{self, RunLoopHandle};
 use xi_win_shell::window::{WindowBuilder, WindowHandle, WinHandler};
 
-struct Resources {
-    fg: brush::SolidColor,
-    bg: brush::SolidColor,
-    text_format: TextFormat,
-}
-
-impl Resources {
-    fn create_text_layout(&self, factory: &directwrite::Factory, text: &str) -> TextLayout {
-        let params = text_layout::ParamBuilder::new()
-            .text(text)
-            .font(self.text_format.clone())
-            .width(1e6)
-            .height(1e6)
-            .build().unwrap();
-        factory.create(params).unwrap()
-    }
-}
-
 struct MainWinState {
     rpc_id: usize,
-    view_id: String,
-    line_cache: LineCache,
     label: String,
-    dwrite_factory: directwrite::Factory,
-    resources: Option<Resources>,
-    filename: Option<String>,
+    edit_view: EditView,
 }
 
 impl MainWinState {
     fn new() -> MainWinState {
         MainWinState {
             rpc_id: 0,
-            view_id: String::new(),
-            line_cache: LineCache::new(),
             label: "hello direct2d".to_string(),
-            dwrite_factory: directwrite::Factory::new().unwrap(),
-            resources: None,
-            filename: None
-        }
-    }
-
-    fn create_resources(&mut self, p: &mut PaintCtx) -> Resources {
-        let rt = p.render_target();
-        let text_format_params = text_format::ParamBuilder::new()
-            .size(15.0)
-            .family("Consolas")
-            .build().unwrap();
-        let text_format = self.dwrite_factory.create(text_format_params).unwrap();
-        Resources {
-            fg: rt.create_solid_color_brush(0xf0f0ea, &BrushProperties::default()).unwrap(),
-            bg: rt.create_solid_color_brush(0x272822, &BrushProperties::default()).unwrap(),
-            text_format: text_format,
+            edit_view: EditView::new(),
         }
     }
 
     fn render(&mut self, p: &mut PaintCtx) {
-        if self.resources.is_none() {
-            self.resources = Some(self.create_resources(p));
-        }
-        let resources = &self.resources.as_ref().unwrap();
-        let rt = p.render_target();
-        let size = rt.get_size();
-        let rect = RectF::from((0.0, 0.0, size.width, size.height));
-        rt.fill_rectangle(&rect, &resources.bg);
-
-        let x0 = 6.0;
-        let mut y = 6.0;
-        for line_num in 0..self.line_cache.height() {
-            if let Some(line) = self.line_cache.get_line(line_num) {
-                let layout = resources.create_text_layout(&self.dwrite_factory, line.text());
-                rt.draw_text_layout(
-                    &Point2F::from((x0, y)),
-                    &layout,
-                    &resources.fg,
-                    default_text_options()
-                );
-                for &offset in line.cursor() {
-                    if let Some(pos) = layout.hit_test_text_position(offset as u32, true) {
-                        let x = x0 + pos.point_x;
-                        rt.draw_line(&Point2F::from((x, y)),
-                            &Point2F::from((x, y + 17.0)),
-                            &resources.fg, 1.0, None);
-                    }
-                }
-            }
-            y += 17.0;
-        }
+        self.edit_view.render(p);
     }
 }
 
@@ -159,7 +83,7 @@ struct MainWinHandler {
 }
 
 // Maybe combine all this, put as a single item inside a RefCell.
-struct MainWin {
+pub struct MainWin {
     peer: XiPeer,
     handle: RefCell<WindowHandle>,
     state: RefCell<MainWinState>,
@@ -183,8 +107,7 @@ impl MainWin {
     }
 
     // Note: caller can't be borrowing the state.
-    fn send_edit_cmd(&self, method: &str, params: &Value) {
-        let view_id = &self.state.borrow_mut().view_id;
+    fn send_edit_cmd(&self, method: &str, params: &Value, view_id: &str) {
         let edit_params = json!({
             "method": method,
             "params": params,
@@ -198,19 +121,19 @@ impl MainWin {
         if let Some(filename) = filename {
             self.req_new_view(Some(&filename));
             let mut state = self.state.borrow_mut();
-            state.filename = Some(filename);
-            state.line_cache = LineCache::new();
+            state.edit_view.filename = Some(filename);
+            state.edit_view.clear_line_cache();
         }
     }
 
     fn file_save(&self, hwnd_owner: HWND) {
-        let filename: Option<String> = self.state.borrow_mut().filename.clone();
+        let filename: Option<String> = self.state.borrow_mut().edit_view.filename.clone();
         if filename.is_none() {
             self.file_save_as(hwnd_owner);
         } else {
             let state = self.state.borrow_mut();
             self.send_notification("save", &json!({
-                "view_id": state.view_id,
+                "view_id": state.edit_view.view_id,
                 "file_path": filename,
             }));
         }
@@ -220,11 +143,11 @@ impl MainWin {
         if let Some(filename) = unsafe { get_save_file_dialog_path(hwnd_owner) } {
             let mut state = self.state.borrow_mut();
             self.send_notification("save", &json!({
-                "view_id": state.view_id,
+                "view_id": state.edit_view.view_id,
                 "file_path": filename,
             }));
 
-            state.filename = Some(filename.clone());
+            state.edit_view.filename = Some(filename.clone());
         }
     }
 
@@ -277,44 +200,14 @@ impl WinHandler for MainWinHandler {
         }
     }
 
-    fn char(&self, ch: u32, _mods: u32) {
-        match ch {
-            0x08 => {
-                self.win.send_edit_cmd("delete_backward", &json!([]));
-            },
-            0x0d => {
-                self.win.send_edit_cmd("insert_newline", &json!([]));
-            },
-            _ => {
-                if let Some(c) = ::std::char::from_u32(ch) {
-                    let params = json!({"chars": c.to_string()});
-                    self.win.send_edit_cmd("insert", &params);
-                }
-            }
-        }
+    fn char(&self, ch: u32, mods: u32) {
+        let edit_view = &mut self.win.state.borrow_mut().edit_view;
+        edit_view.char(ch, mods, &self.win);
     }
 
-    fn keydown(&self, vk_code: i32, _mods: u32) -> bool {
-        // Handle special keys here
-        match vk_code {
-            VK_UP => {
-                self.win.send_edit_cmd("move_up", &json!([]));
-            },
-            VK_DOWN => {
-                self.win.send_edit_cmd("move_down", &json!([]));
-            },
-            VK_LEFT => {
-                self.win.send_edit_cmd("move_left", &json!([]));
-            },
-            VK_RIGHT => {
-                self.win.send_edit_cmd("move_right", &json!([]));
-            },
-            VK_DELETE => {
-                self.win.send_edit_cmd("delete_forward", &json!([]));
-            },
-            _ => return false
-        }
-        true
+    fn keydown(&self, vk_code: i32, mods: u32) -> bool {
+        let edit_view = &mut self.win.state.borrow_mut().edit_view;
+        edit_view.keydown(vk_code, mods, &self.win)
     }
 
     fn destroy(&self) {
@@ -328,11 +221,11 @@ impl MainWin {
         //println!("got {:?}", v);
         if let Some(tab_name) = v["result"].as_str() {
             // TODO: should match up id etc. This is quick and dirty.
-            state.view_id = tab_name.to_string();
+            state.edit_view.set_view_id(tab_name);
         } else {
             let ref method = v["method"];
             if method == "update" {
-                state.line_cache.apply_update(&v["params"]["update"]);
+                state.edit_view.apply_update(&v["params"]["update"]);
             }
         }
         state.label = serde_json::to_string(v).unwrap();

--- a/xi-win-shell/examples/hello.rs
+++ b/xi-win-shell/examples/hello.rs
@@ -22,7 +22,7 @@ use direct2d::math::*;
 use xi_win_shell::menu::Menu;
 use xi_win_shell::paint::PaintCtx;
 use xi_win_shell::win_main;
-use xi_win_shell::window::{WindowBuilder, WindowHandle, WinHandler};
+use xi_win_shell::window::{MouseButton, MouseType, WindowBuilder, WindowHandle, WinHandler};
 
 #[derive(Default)]
 struct HelloState {
@@ -55,12 +55,29 @@ impl WinHandler for HelloState {
         }
     }
 
-    fn char(&self, ch: u32) {
-        println!("got char 0x{:x}", ch);
+    fn char(&self, ch: u32, mods: u32) {
+        println!("got char 0x{:x} {:02x}", ch, mods);
     }
 
-    fn keydown(&self, vk_code: i32) {
-        println!("got key code 0x{:x}", vk_code);
+    fn keydown(&self, vk_code: i32, mods: u32) -> bool {
+        println!("got key code 0x{:x} {:02x}", vk_code, mods);
+        false
+    }
+
+    fn mouse_wheel(&self, delta: i32, mods: u32) {
+        println!("mouse_wheel {} {:02x}", delta, mods);
+    }
+
+    fn mouse_hwheel(&self, delta: i32, mods: u32) {
+        println!("mouse_hwheel {} {:02x}", delta, mods);
+    }
+
+    fn mouse_move(&self, x: i32, y: i32, mods: u32) {
+        println!("mouse_move ({}, {}) {:02x}", x, y, mods);
+    }
+
+    fn mouse(&self, x: i32, y: i32, mods: u32, button: MouseButton, ty: MouseType) {
+        println!("mouse_move ({}, {}) {:02x} {:?} {:?}", x, y, mods, button, ty);
     }
 
     fn destroy(&self) {

--- a/xi-win-shell/examples/perftest.rs
+++ b/xi-win-shell/examples/perftest.rs
@@ -107,12 +107,13 @@ impl WinHandler for PerfTest {
         }
     }
 
-    fn char(&self, ch: u32) {
-        println!("got char 0x{:x}", ch);
+    fn char(&self, ch: u32, mods: u32) {
+        println!("got char 0x{:x} {:02x}", ch, mods);
     }
 
-    fn keydown(&self, vk_code: i32) {
-        println!("got key code 0x{:x}", vk_code);
+    fn keydown(&self, vk_code: i32, mods: u32) -> bool {
+        println!("got key code 0x{:x} {:02x}", vk_code, mods);
+        false
     }
 
     fn destroy(&self) {

--- a/xi-win-shell/src/win_main.rs
+++ b/xi-win-shell/src/win_main.rs
@@ -86,6 +86,12 @@ impl RunLoop {
                     0
                 );
 
+                // Prioritize rpc results above windows messages
+                if res >= WAIT_OBJECT_0 && res < WAIT_OBJECT_0 + len {
+                    let ix = (res - WAIT_OBJECT_0) as usize;
+                    (&mut self.handle.0.borrow_mut().listeners[ix].callback)();
+                }
+
                 // Handle windows messages
                 loop {
                     let mut msg = mem::uninitialized();
@@ -100,11 +106,6 @@ impl RunLoop {
                     }
                     TranslateMessage(&mut msg);
                     DispatchMessageW(&mut msg);
-                }
-
-                if res >= WAIT_OBJECT_0 && res < WAIT_OBJECT_0 + len {
-                    let ix = (res - WAIT_OBJECT_0) as usize;
-                    (&mut self.handle.0.borrow_mut().listeners[ix].callback)();
                 }
             }
         }


### PR DESCRIPTION
These commits have work on both xi-win-shell (mouse bindings, improvements to keyboard, access to dpi info) and on xi-win (refactor of edit view into its own module, beginnings of vertical scroll).

Scroll performance is terrible, because repaints systematically starve the notification from core to front-end. I could tweak MsgWaitForMultipleObjectsEx priorities, but the right thing to do here is update the line cache from a separate thread (as is done on xi-mac).