### PR TITLE
Switch to flip + hwnd hybrid approach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/edit_view.rs
+++ b/src/edit_view.rs
@@ -84,6 +84,10 @@ impl EditView {
         }
     }
 
+    pub fn rebuild_resources(&mut self) {
+        self.resources = None;
+    }
+
     pub fn size(&mut self, x: f32, y: f32) {
         self.size = (x, y);
         self.constrain_scroll();

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,6 +184,11 @@ impl WinHandler for MainWinHandler {
         false
     }
 
+    fn rebuild_resources(&self) {
+        let mut state = self.win.state.borrow_mut();
+        state.edit_view.rebuild_resources();
+    }
+
     fn command(&self, id: u32) {
         match id {
             x if x == MenuEntries::Exit as u32 => {

--- a/xi-win-shell/Cargo.lock
+++ b/xi-win-shell/Cargo.lock
@@ -78,6 +78,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]

--- a/xi-win-shell/Cargo.toml
+++ b/xi-win-shell/Cargo.toml
@@ -14,4 +14,4 @@ time = "0.1.39"
 
 [dependencies.winapi]
 version = "0.3"
-features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser", "shellscalingapi", "shobjidl", "combaseapi", "synchapi", "dxgi1_3", "d3d11"]
+features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser", "shellscalingapi", "shobjidl", "combaseapi", "synchapi", "dxgi1_3", "d3d11", "dwmapi"]

--- a/xi-win-shell/Cargo.toml
+++ b/xi-win-shell/Cargo.toml
@@ -14,4 +14,4 @@ time = "0.1.39"
 
 [dependencies.winapi]
 version = "0.3"
-features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser", "shellscalingapi", "shobjidl", "combaseapi", "synchapi"]
+features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser", "shellscalingapi", "shobjidl", "combaseapi", "synchapi", "dxgi1_3", "d3d11"]

--- a/xi-win-shell/Cargo.toml
+++ b/xi-win-shell/Cargo.toml
@@ -8,10 +8,11 @@ description = "Windows-specific application shell used for xi editor."
 [dependencies]
 directwrite = "0.0.9"
 direct2d = "0.0.9"
+wio = "0.2"
 
 lazy_static = "1.0"
 time = "0.1.39"
 
 [dependencies.winapi]
 version = "0.3"
-features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser", "shellscalingapi", "shobjidl", "combaseapi", "synchapi", "dxgi1_3", "d3d11", "dwmapi"]
+features = ["d2d1_1", "dwrite", "winbase", "libloaderapi", "errhandlingapi", "winuser", "shellscalingapi", "shobjidl", "combaseapi", "synchapi", "dxgi1_3", "dcomp", "d3d11", "dwmapi"]

--- a/xi-win-shell/examples/perftest.rs
+++ b/xi-win-shell/examples/perftest.rs
@@ -134,7 +134,7 @@ fn main() {
     builder.set_handler(Box::new(PerfTest(RefCell::new(perf_state))));
     builder.set_title("Performance tester");
     // Note: experiment with changing this
-    builder.set_present_strategy(PresentStrategy::Flip);
+    builder.set_present_strategy(PresentStrategy::FlipRedirect);
     let window = builder.build().unwrap();
     window.show();
     run_loop.run();

--- a/xi-win-shell/examples/perftest.rs
+++ b/xi-win-shell/examples/perftest.rs
@@ -27,7 +27,7 @@ use directwrite::text_format;
 use xi_win_shell::paint::PaintCtx;
 use xi_win_shell::util::default_text_options;
 use xi_win_shell::win_main;
-use xi_win_shell::window::{WindowBuilder, WindowHandle, WinHandler};
+use xi_win_shell::window::{PresentStrategy, WindowBuilder, WindowHandle, WinHandler};
 
 struct PerfTest(RefCell<PerfState>);
 
@@ -133,6 +133,8 @@ fn main() {
     };
     builder.set_handler(Box::new(PerfTest(RefCell::new(perf_state))));
     builder.set_title("Performance tester");
+    // Note: experiment with changing this
+    builder.set_present_strategy(PresentStrategy::Flip);
     let window = builder.build().unwrap();
     window.show();
     run_loop.run();

--- a/xi-win-shell/src/dcomp.rs
+++ b/xi-win-shell/src/dcomp.rs
@@ -1,0 +1,238 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Safe-ish wrappers for DirectComposition and related interfaces.
+
+// This module could become a general wrapper for DirectComposition, but
+// for now we're just using what we need to get a swapchain up.
+#![allow(unused)]
+
+use std::ops::{Deref, DerefMut};
+use std::mem;
+use std::ptr::{null, null_mut};
+use winapi::Interface;
+use winapi::shared::dxgi::IDXGIDevice;
+use winapi::shared::dxgi1_2::DXGI_ALPHA_MODE_IGNORE;
+use winapi::shared::dxgiformat::DXGI_FORMAT_B8G8R8A8_UNORM;
+use winapi::shared::minwindef::{FALSE, TRUE};
+use winapi::shared::windef::{HWND, POINT, RECT};
+use winapi::shared::winerror::SUCCEEDED;
+use winapi::um::d2d1::*;
+use winapi::um::d2d1_1::*;
+use winapi::um::d3d11::*;
+use winapi::um::d3dcommon::D3D_DRIVER_TYPE_HARDWARE;
+use winapi::um::unknwnbase::IUnknown;
+use winapi::um::dcomp::*;
+use winapi::um::dcompanimation::*;
+use winapi::um::winnt::HRESULT;
+use wio::com::ComPtr;
+
+use direct2d::{self, RenderTarget};
+use direct2d::error::D2D1Error;
+use direct2d::math::Matrix3x2F;
+use direct2d::render_target::RenderTargetBacking;
+
+unsafe fn wrap<T, U, F>(hr: HRESULT, ptr: *mut T, f: F) -> Result<U, HRESULT>
+    where F: Fn(ComPtr<T>) -> U, T: Interface
+{
+    if SUCCEEDED(hr) {
+        Ok(f(ComPtr::from_raw(ptr)))
+    } else {
+        Err(hr)
+    }
+}
+
+fn unit_err(hr: HRESULT) -> Result<(), HRESULT> {
+    if SUCCEEDED(hr) { Ok(()) } else { Err(hr) }
+}
+
+pub struct D3D11Device(ComPtr<ID3D11Device>);
+pub struct D2D1Device(ComPtr<ID2D1Device>);
+pub struct DCompositionDevice(ComPtr<IDCompositionDevice>);
+pub struct DCompositionTarget(ComPtr<IDCompositionTarget>);
+pub struct DCompositionVisual(ComPtr<IDCompositionVisual>);
+pub struct DCompositionVirtualSurface(ComPtr<IDCompositionVirtualSurface>);
+
+/// A trait for content which can be added to a visual.
+pub trait Content {
+    unsafe fn unknown_ptr(&mut self) -> *mut IUnknown;
+}
+
+impl D3D11Device {
+    /// Creates a new device with basic defaults.
+    pub fn new_simple() -> Result<D3D11Device, HRESULT> {
+        unsafe {
+            let mut d3d11_device: *mut ID3D11Device = null_mut();
+            let flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;  // could probably set single threaded
+            let hr = D3D11CreateDevice(null_mut(), D3D_DRIVER_TYPE_HARDWARE, null_mut(), flags,
+                null(), 0, D3D11_SDK_VERSION, &mut d3d11_device, null_mut(), null_mut());
+            wrap(hr, d3d11_device, D3D11Device)
+        }
+    }
+
+    pub fn create_d2d1_device(&mut self) -> Result<D2D1Device, HRESULT> {
+        unsafe {
+            let mut dxgi_device: ComPtr<IDXGIDevice> = self.0.cast()?;
+            let mut d2d1_device: *mut ID2D1Device = null_mut();
+            let hr = D2D1CreateDevice(dxgi_device.as_raw(), null(), &mut d2d1_device);
+            wrap(hr, d2d1_device, D2D1Device)
+        }
+    }
+
+    pub fn raw_ptr(&mut self) -> *mut ID3D11Device {
+        self.0.as_raw()
+    }
+}
+
+impl D2D1Device {
+    pub fn create_composition_device(&mut self) -> Result<DCompositionDevice, HRESULT> {
+        unsafe {
+            let mut dcomp_device: *mut IDCompositionDevice = null_mut();
+            let hr = DCompositionCreateDevice2(self.0.as_raw() as *mut IUnknown,
+                &IDCompositionDevice::uuidof(),
+                &mut dcomp_device as *mut _ as *mut _);
+            wrap(hr, dcomp_device, DCompositionDevice)
+        }
+    }
+}
+
+impl DCompositionDevice {
+    pub unsafe fn create_target_for_hwnd(&mut self, hwnd: HWND, topmost: bool)
+        -> Result<DCompositionTarget, HRESULT>
+    {
+        let mut dcomp_target: *mut IDCompositionTarget = null_mut();
+        let hr = self.0.CreateTargetForHwnd(hwnd, if topmost { TRUE } else { FALSE },
+            &mut dcomp_target);
+        wrap(hr, dcomp_target, DCompositionTarget)
+    }
+
+    pub fn create_visual(&mut self) -> Result<DCompositionVisual, HRESULT> {
+        unsafe {
+            let mut visual: *mut IDCompositionVisual = null_mut();
+            let hr = self.0.CreateVisual(&mut visual);
+            wrap(hr, visual, DCompositionVisual)
+        }
+    }
+
+    /// Creates an RGB surface. Probably should allow more options (including alpha).
+    pub fn create_virtual_surface(&mut self, height: u32, width: u32)
+        -> Result<DCompositionVirtualSurface, HRESULT>
+    {
+        unsafe {
+            let mut surface: *mut IDCompositionVirtualSurface = null_mut();
+            let hr = self.0.CreateVirtualSurface(width, height, DXGI_FORMAT_B8G8R8A8_UNORM,
+                DXGI_ALPHA_MODE_IGNORE, &mut surface);
+            wrap(hr, surface, DCompositionVirtualSurface)
+        }
+    }
+
+    pub fn commit(&mut self) -> Result<(), HRESULT> {
+        unsafe {
+            unit_err(self.0.Commit())
+        }
+    }
+}
+
+impl DCompositionTarget {
+    // alternatively could be set_root with an option
+    pub fn clear_root(&mut self) -> Result<(), HRESULT> {
+        unsafe {
+            unit_err(self.0.SetRoot(null_mut()))
+        }
+    }
+
+    pub fn set_root(&mut self, visual: &mut DCompositionVisual) -> Result<(), HRESULT> {
+        unsafe {
+            unit_err(self.0.SetRoot(visual.0.as_raw()))
+        }
+    }
+}
+
+impl DCompositionVisual {
+    pub fn set_content<T: Content>(&mut self, content: &mut T) -> Result<(), HRESULT> {
+        unsafe {
+            self.set_content_raw(content.unknown_ptr())
+        }
+    }
+
+    // TODO: impl Content trait for swapchain, for type safety
+    pub unsafe fn set_content_raw(&mut self, content: *mut IUnknown) -> Result<(), HRESULT> {
+        unit_err(self.0.SetContent(content))
+    }
+
+    pub fn set_pos(&mut self, x: f32, y: f32) {
+        unsafe {
+            self.0.SetOffsetX_1(x);
+            self.0.SetOffsetY_1(y);
+        }
+    }
+}
+
+struct DcBacking(*mut ID2D1DeviceContext);
+unsafe impl RenderTargetBacking for DcBacking {
+    fn create_target(self, _factory: &mut ID2D1Factory1) -> Result<*mut ID2D1RenderTarget, HRESULT> {
+        Ok(self.0 as *mut ID2D1RenderTarget)
+    }
+}
+
+// TODO: support common methods with DCompositionSurface, probably should be trait
+impl DCompositionVirtualSurface {
+    // could try to expose more DeviceContext capability
+    pub fn begin_draw(&mut self, d2d_factory: &direct2d::Factory, rect: Option<RECT>)
+        -> Result<RenderTarget, HRESULT>
+    {
+        unsafe {
+            let mut dc: *mut ID2D1DeviceContext = null_mut();
+            let rect_ptr = match rect {
+                None => null(),
+                Some(r) => &r,
+            };
+            let mut offset: POINT = mem::uninitialized();
+            let hr = self.0.BeginDraw(rect_ptr, &ID2D1DeviceContext::uuidof(),
+                &mut dc as *mut _ as *mut _, &mut offset);
+            if !SUCCEEDED(hr) {
+                return Err(hr);
+            }
+            let backing = DcBacking(dc);
+            let mut rt = d2d_factory.create_render_target(backing).map_err(|e|
+                match e {
+                    D2D1Error::ComError(hr) => hr,
+                    _ => 0,
+                })?;
+            // TODO: either move dpi scaling somewhere else or figure out how to
+            // set it correctly here.
+            rt.set_transform(&Matrix3x2F::new([[2.0, 0.0], [0.0, 2.0],
+                [offset.x as f32, offset.y as f32]]));
+            Ok(rt)
+        }
+    }
+
+    pub fn end_draw(&mut self) -> Result<(), HRESULT> {
+        unsafe {
+            unit_err(self.0.EndDraw())
+        }
+    }
+
+    pub fn resize(&mut self, width: u32, height: u32) -> Result<(), HRESULT> {
+        unsafe {
+            unit_err(self.0.Resize(width, height))
+        }
+    }
+}
+
+impl Content for DCompositionVirtualSurface {
+    unsafe fn unknown_ptr(&mut self) -> *mut IUnknown {
+        self.0.as_raw() as *mut IUnknown
+    }
+}

--- a/xi-win-shell/src/lib.rs
+++ b/xi-win-shell/src/lib.rs
@@ -16,9 +16,11 @@
 
 extern crate winapi;
 extern crate direct2d;
+extern crate wio;
 #[macro_use]
 extern crate lazy_static;
 
+mod dcomp;
 pub mod menu;
 pub mod paint;
 pub mod util;

--- a/xi-win-shell/src/paint.rs
+++ b/xi-win-shell/src/paint.rs
@@ -38,6 +38,7 @@ use direct2d;
 use direct2d::render_target::{RenderTarget, RenderTargetBacking};
 
 use Error;
+use util::as_result;
 
 /// Context for painting by app into window.
 pub struct PaintCtx<'a> {
@@ -135,8 +136,8 @@ pub(crate) unsafe fn create_render_target_dxgi(d2d_factory: &direct2d::Factory,
     swap_chain: *mut IDXGISwapChain1, dpi: f32) -> Result<RenderTarget, Error>
 {
     let mut buffer: *mut IDXGISurface = null_mut();
-    let res = (*swap_chain).GetBuffer(0, &IDXGISurface::uuidof(),
-        &mut buffer as *mut _ as *mut *mut c_void);
+    as_result((*swap_chain).GetBuffer(0, &IDXGISurface::uuidof(),
+        &mut buffer as *mut _ as *mut *mut c_void))?;
     let backing = DxgiBacking(buffer, dpi);
     let result = d2d_factory.create_render_target(backing);
     (*buffer).Release();

--- a/xi-win-shell/src/util.rs
+++ b/xi-win-shell/src/util.rs
@@ -25,6 +25,7 @@ use std::mem;
 use winapi::shared::minwindef::*;
 use winapi::shared::ntdef::*;
 use winapi::shared::windef::*;
+use winapi::shared::winerror::SUCCEEDED;
 use winapi::um::libloaderapi::*;
 use winapi::um::shellscalingapi::*;
 
@@ -40,14 +41,13 @@ pub enum Error {
     D2Error,
 }
 
-/*
 pub fn as_result(hr: HRESULT) -> Result<(), Error> {
-    match hr {
-        S_OK => Ok(()),
-        _ => Err(Error::Hr(hr)),
+    if SUCCEEDED(hr) {
+        Ok(())
+    } else {
+        Err(Error::Hr(hr))
     }
 }
-*/
 
 impl From<HRESULT> for Error {
     fn from(hr: HRESULT) -> Error {

--- a/xi-win-shell/src/util.rs
+++ b/xi-win-shell/src/util.rs
@@ -22,12 +22,15 @@ use std::os::windows::ffi::OsStrExt;
 use std::slice;
 use std::mem;
 
+use winapi::ctypes::c_void;
+use winapi::shared::guiddef::REFIID;
 use winapi::shared::minwindef::*;
 use winapi::shared::ntdef::*;
 use winapi::shared::windef::*;
 use winapi::shared::winerror::SUCCEEDED;
 use winapi::um::libloaderapi::*;
 use winapi::um::shellscalingapi::*;
+use winapi::um::unknwnbase::IUnknown;
 
 use direct2d::render_target::DrawTextOption;
 
@@ -39,6 +42,8 @@ pub enum Error {
     Hr(HRESULT),
     // Maybe include the full error from the direct2d crate.
     D2Error,
+    /// A function is available on newer version of windows.
+    OldWindows,
 }
 
 pub fn as_result(hr: HRESULT) -> Result<(), Error> {
@@ -97,12 +102,24 @@ type GetDpiForSystem = unsafe extern "system" fn() -> UINT;
 type GetDpiForMonitor = unsafe extern "system" fn(HMONITOR, MONITOR_DPI_TYPE, *mut UINT, *mut UINT);
 // from user32.dll
 type SetProcessDpiAwareness = unsafe extern "system" fn(PROCESS_DPI_AWARENESS) -> HRESULT;
+type DCompositionCreateDevice2 = unsafe extern "system" fn(
+    renderingDevice: *const IUnknown,
+    iid: REFIID,
+    dcompositionDevice: *mut *mut c_void,
+) -> HRESULT;
+type CreateDXGIFactory2 = unsafe extern "system" fn(
+    Flags: UINT,
+    riid: REFIID,
+    ppFactory: *mut *mut c_void,
+) -> HRESULT;
 
 #[allow(non_snake_case)] // For member fields
 pub struct OptionalFunctions {
     pub GetDpiForSystem: Option<GetDpiForSystem>,
     pub GetDpiForMonitor: Option<GetDpiForMonitor>,
     pub SetProcessDpiAwareness: Option<SetProcessDpiAwareness>,
+    pub DCompositionCreateDevice2: Option<DCompositionCreateDevice2>,
+    pub CreateDXGIFactory2: Option<CreateDXGIFactory2>,
 }
 
 #[allow(non_snake_case)] // For local variables
@@ -135,7 +152,7 @@ fn load_optional_functions() -> OptionalFunctions {
     fn load_library(name: &str) -> HMODULE {
         let encoded_name = name.to_wide();
 
-        // If we allready have loaded the library (somewhere else in the process) we don't need to
+        // If we already have loaded the library (somewhere else in the process) we don't need to
         // call LoadLibrary again
         let library = unsafe { GetModuleHandleW(encoded_name.as_ptr()) };
         if !library.is_null() {
@@ -148,10 +165,14 @@ fn load_optional_functions() -> OptionalFunctions {
 
     let shcore = load_library("shcore.dll");
     let user32 = load_library("user32.dll");
+    let dcomp = load_library("dcomp.dll");
+    let dxgi = load_library("dxgi.dll");
 
     let mut GetDpiForSystem = None;
     let mut GetDpiForMonitor = None;
     let mut SetProcessDpiAwareness = None;
+    let mut DCompositionCreateDevice2 = None;
+    let mut CreateDXGIFactory2 = None;
 
     if shcore.is_null() {
         println!("No shcore.dll");
@@ -166,10 +187,20 @@ fn load_optional_functions() -> OptionalFunctions {
         load_function!(user32, GetDpiForSystem, "10");
     }
 
+    if !dcomp.is_null() {
+        load_function!(dcomp, DCompositionCreateDevice2, "8.1");
+    }
+
+    if !dxgi.is_null() {
+        load_function!(dxgi, CreateDXGIFactory2, "8.1");
+    }
+
     OptionalFunctions {
         GetDpiForSystem,
         GetDpiForMonitor,
         SetProcessDpiAwareness,
+        DCompositionCreateDevice2,
+        CreateDXGIFactory2,
     }
 }
 


### PR DESCRIPTION
This is an attempt to address #17, merging the flip + hwnd hybrid approach discussed in #19 (and thanks to the testers).

The hybrid approach only works on Windows 8.1 and up, so we use optional functions to set up composition and the swap chain. On Windows 7, all presentation is with the hwnd approach.