### PR TITLE
Start building RPC infrastructure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,11 +38,13 @@ mod dialog;
 mod edit_view;
 mod linecache;
 mod menus;
+mod rpc;
 mod xi_thread;
 
+use std::any::Any;
 use std::cell::RefCell;
-use std::sync::mpsc::TryRecvError;
 use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
 use winapi::shared::windef::*;
 
@@ -50,25 +52,22 @@ use serde_json::Value;
 
 use edit_view::EditView;
 use menus::MenuEntries;
+use rpc::{Core, Handler};
 use xi_win_shell::util::Error;
 use dialog::{get_open_file_dialog_path, get_save_file_dialog_path};
-use xi_thread::{start_xi_thread, XiPeer};
+use xi_thread::start_xi_thread;
 
 use xi_win_shell::paint::PaintCtx;
 use xi_win_shell::win_main::{self, RunLoopHandle};
-use xi_win_shell::window::{WindowBuilder, WindowHandle, WinHandler};
+use xi_win_shell::window::{IdleHandle, WindowBuilder, WindowHandle, WinHandler};
 
 struct MainWinState {
-    rpc_id: usize,
-    label: String,
     edit_view: EditView,
 }
 
 impl MainWinState {
     fn new() -> MainWinState {
         MainWinState {
-            rpc_id: 0,
-            label: "hello direct2d".to_string(),
             edit_view: EditView::new(),
         }
     }
@@ -84,26 +83,22 @@ struct MainWinHandler {
 
 // Maybe combine all this, put as a single item inside a RefCell.
 pub struct MainWin {
-    peer: XiPeer,
+    core: RefCell<Core>,
     handle: RefCell<WindowHandle>,
     state: RefCell<MainWinState>,
 }
 
 impl MainWin {
-    fn new(peer: XiPeer, state: MainWinState) -> MainWin {
+    fn new(core: Core, state: MainWinState) -> MainWin {
         MainWin {
-            peer: peer,
+            core: RefCell::new(core),
             handle: Default::default(),
             state: RefCell::new(state),
         }
     }
 
     fn send_notification(&self, method: &str, params: &Value) {
-        let cmd = json!({
-            "method": method,
-            "params": params,
-        });
-        self.peer.send_json(&cmd);
+        self.core.borrow().send_notification(method, params);
     }
 
     // Note: caller can't be borrowing the state.
@@ -119,7 +114,8 @@ impl MainWin {
     fn file_open(&self, hwnd_owner: HWND) {
         let filename = unsafe { get_open_file_dialog_path(hwnd_owner) };
         if let Some(filename) = filename {
-            self.req_new_view(Some(&filename));
+            // TODO
+            //self.req_new_view(Some(&filename));
             let mut state = self.state.borrow_mut();
             state.edit_view.filename = Some(filename);
             state.edit_view.clear_line_cache();
@@ -150,27 +146,13 @@ impl MainWin {
             state.edit_view.filename = Some(filename.clone());
         }
     }
-
-    fn req_new_view(&self, filename: Option<&str>) {
-        let mut params = json!({});
-        if let Some(filename) = filename {
-            params["file_path"] = json!(filename);
-        }
-        let cmd = json!({
-            "method": "new_view",
-            "params": params,
-            "id": self.state.borrow().rpc_id,
-        });
-        self.state.borrow_mut().rpc_id += 1;
-        self.peer.send_json(&cmd);
-    }
 }
 
 impl WinHandler for MainWinHandler {
     fn connect(&self, handle: &WindowHandle) {
         *self.win.handle.borrow_mut() = handle.clone();
         self.win.send_notification("client_started", &json!({}));
-        self.win.req_new_view(None);
+        self.req_new_view(None);
     }
 
     fn size(&self, x: u32, y: u32) {
@@ -228,66 +210,97 @@ impl WinHandler for MainWinHandler {
     fn destroy(&self) {
         win_main::request_quit();
     }
+
+    fn as_any(&self) -> &Any { self }
+}
+
+impl MainWinHandler {
+    fn req_new_view(&self, filename: Option<&str>) {
+        let mut params = json!({});
+        if let Some(filename) = filename {
+            params["file_path"] = json!(filename);
+        }
+        let handle = self.win.handle.borrow().get_idle_handle().unwrap();
+        self.win.core.borrow_mut().send_request("new_view", &params,
+            move |value| {
+                let value = value.clone();
+                handle.add_idle(move |a| {
+                    let handler = a.downcast_ref::<MainWinHandler>().unwrap();
+                    let edit_view = &mut handler.win.state.borrow_mut().edit_view;
+                    edit_view.set_view_id(value.as_str().unwrap());
+                });
+            }
+        );
+    }
 }
 
 impl MainWin {
-    fn handle_cmd(&self, v: &Value) {
+    fn handle_cmd(&self, method: &str, params: &Value) {
         let mut state = self.state.borrow_mut();
         //println!("got {:?}", v);
-        if let Some(tab_name) = v["result"].as_str() {
-            // TODO: should match up id etc. This is quick and dirty.
-            state.edit_view.set_view_id(tab_name);
-        } else {
-            let ref method = v["method"];
-            if method == "update" {
-                state.edit_view.apply_update(&v["params"]["update"]);
-            }
+        if method == "update" {
+            state.edit_view.apply_update(&params["update"]);
         }
-        state.label = serde_json::to_string(v).unwrap();
         self.handle.borrow().invalidate();
     }
 }
 
-fn create_main(xi_peer: XiPeer, run_loop: RunLoopHandle)
-    -> Result<(WindowHandle, Rc<MainWin>), Error>
-{
+fn create_main(core: Core) -> Result<WindowHandle, Error> {
     let main_state = MainWinState::new();
-    let main_win = Rc::new(MainWin::new(xi_peer, main_state));
+    let main_win = Rc::new(MainWin::new(core, main_state));
     let main_win_handler = MainWinHandler {
-        win: main_win.clone(),
+        win: main_win,
     };
 
     let menubar = menus::create_menus();
 
-    let mut builder = WindowBuilder::new(run_loop);
+    let mut builder = WindowBuilder::new();
     builder.set_handler(Box::new(main_win_handler));
     builder.set_title("xi-editor");
     builder.set_menu(menubar);
     let window = builder.build().unwrap();
-    Ok((window, main_win))
+    Ok(window)
+}
+
+#[derive(Clone)]
+struct MyHandler {
+    runloop: RunLoopHandle,
+    win_handle: Arc<Mutex<Option<IdleHandle>>>,
+}
+
+impl MyHandler {
+    fn new(runloop: RunLoopHandle) -> MyHandler {
+        MyHandler {
+            runloop,
+            win_handle: Default::default(),
+        }
+    }
+}
+
+impl Handler for MyHandler {
+    fn notification(&self, method: &str, params: &Value) {
+        if let Some(idle_handle) = self.win_handle.lock().unwrap().as_ref() {
+            // Note: could pass these by ownership, but we'll change where they get parsed.
+            let method = method.to_owned();
+            let params = params.clone();
+            idle_handle.add_idle(move |a| {
+                let handler = a.downcast_ref::<MainWinHandler>().unwrap();
+                handler.win.handle_cmd(&method, &params);
+            });
+        }
+    }
 }
 
 fn main() {
     xi_win_shell::init();
 
-    let (xi_peer, rx, semaphore) = start_xi_thread();
+    let (xi_peer, rx) = start_xi_thread();
 
-    let mut run_loop = win_main::RunLoop::new();
-    let (window, main_win) = create_main(xi_peer, run_loop.get_handle()).unwrap();
+    let mut runloop = win_main::RunLoop::new();
+    let handler = MyHandler::new(runloop.get_handle());
+    let core = Core::new(xi_peer, rx, handler.clone());
+    let window = create_main(core).unwrap();
+    *handler.win_handle.lock().unwrap() = window.get_idle_handle();
     window.show();
-    let run_handle = run_loop.get_handle();
-    unsafe {
-        run_handle.add_handler(semaphore.get_handle(), move || {
-            loop {
-                match rx.try_recv() {
-                    Ok(v) => main_win.handle_cmd(&v),
-                    Err(TryRecvError::Disconnected) => {
-                        println!("core disconnected");
-                    }
-                    Err(TryRecvError::Empty) => break,
-                }
-            }
-        });
-    }
-    run_loop.run();
+    runloop.run();
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,0 +1,110 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Front-end side implementation of RPC protocol.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+use std::sync::mpsc::Receiver;
+use std::thread;
+
+use serde_json::Value;
+
+use xi_thread::XiPeer;
+
+#[derive(Clone)]
+pub struct Core {
+    state: Arc<Mutex<CoreState>>,
+}
+
+struct CoreState {
+    xi_peer: XiPeer,
+    id: u64,
+    pending: BTreeMap<u64, Box<Callback>>,
+}
+
+trait Callback: Send {
+    fn call(self: Box<Self>, result: &Value);
+}
+
+pub trait Handler {
+    fn notification(&self, method: &str, params: &Value);
+}
+
+impl<F: FnOnce(&Value) + Send> Callback for F {
+    fn call(self: Box<F>, result: &Value) {
+        (*self)(result)
+    }
+}
+
+impl Core {
+    /// Sets up a new RPC connection, also starting a thread to receive
+    /// responses.
+    ///
+    /// The handler is invoked for incoming RPC notifications. Note that
+    /// it must be `Send` because it is called from a dedicated thread.
+    pub fn new<H>(xi_peer: XiPeer, rx: Receiver<Value>, handler: H) -> Core
+        where H: Handler + Send + 'static
+    {
+        let state = CoreState {
+            xi_peer,
+            id: 0,
+            pending: BTreeMap::new(),
+        };
+        let core = Core { state: Arc::new(Mutex::new(state)) };
+        let rx_core_handle = core.clone();
+        thread::spawn(move || {
+            while let Ok(msg) = rx.recv() {
+                if let Value::String(ref method) = msg["method"] {
+                    handler.notification(&method, &msg["params"]);
+                } else if let Some(id) = msg["id"].as_u64() {
+                    let mut state = rx_core_handle.state.lock().unwrap();
+                    if let Some(callback) = state.pending.remove(&id) {
+                        callback.call(&msg["result"]);
+                    } else {
+                        println!("unexpected result")
+                    }
+                } else {
+                    println!("got {:?} at rpc level", msg);
+                }
+            }
+        });
+        core
+    }
+
+    pub fn send_notification(&self, method: &str, params: &Value) {
+        let cmd = json!({
+            "method": method,
+            "params": params,
+        });
+        let state = self.state.lock().unwrap();
+        state.xi_peer.send_json(&cmd);
+    }
+
+    /// Calls the callback with the result (from a different thread).
+    pub fn send_request<F>(&mut self, method: &str, params: &Value, callback: F)
+        where F: FnOnce(&Value) + Send + 'static
+    {
+        let mut state = self.state.lock().unwrap();
+        let id = state.id;
+        let cmd = json!({
+            "method": method,
+            "params": params,
+            "id": id,
+        });
+        state.xi_peer.send_json(&cmd);
+        state.pending.insert(id, Box::new(callback));
+        state.id += 1;
+    }
+}

--- a/src/xi_thread.rs
+++ b/src/xi_thread.rs
@@ -15,15 +15,14 @@
 //! Startup and communication with the xi core thread.
 
 use std::io::{self, BufRead, ErrorKind, Read, Write};
-use std::marker::Send;
-use std::ptr::null_mut;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
 #[allow(unused_imports)]
 use std::time::Duration;
 
-use winapi::um::synchapi::{CreateSemaphoreW, ReleaseSemaphore};
-use winapi::shared::ntdef::HANDLE;
+// Needed for semaphore, currently disabled
+//use winapi::um::synchapi::{CreateSemaphoreW, ReleaseSemaphore};
+//use winapi::shared::ntdef::HANDLE;
 
 use serde_json::{self, Value};
 
@@ -44,14 +43,12 @@ impl XiPeer {
     }
 }
 
-pub fn start_xi_thread() -> (XiPeer, Receiver<Value>, Semaphore) {
+pub fn start_xi_thread() -> (XiPeer, Receiver<Value>) {
     let (to_core_tx, to_core_rx) = channel();
     let to_core_rx = ChanReader(to_core_rx);
     let (from_core_tx, from_core_rx) = channel();
-    let semaphore = Semaphore::new();
     let from_core_tx = ChanWriter {
         sender: from_core_tx,
-        semaphore: semaphore.clone(),
     };
     let mut state = XiCore::new();
     let mut rpc_looper = RpcLoop::new(from_core_tx);
@@ -61,7 +58,7 @@ pub fn start_xi_thread() -> (XiPeer, Receiver<Value>, Semaphore) {
     let peer = XiPeer {
         tx: to_core_tx,
     };
-    (peer, from_core_rx, semaphore)
+    (peer, from_core_rx)
 }
 
 struct ChanReader(Receiver<String>);
@@ -98,7 +95,6 @@ impl BufRead for ChanReader {
 
 struct ChanWriter {
     sender: Sender<Value>,
-    semaphore: Semaphore,
 }
 
 impl Write for ChanWriter {
@@ -113,14 +109,15 @@ impl Write for ChanWriter {
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
         let json = serde_json::from_slice::<Value>(buf).unwrap();
         //thread::sleep(Duration::from_secs(1));
-        self.sender.send(json).map(|_|
-            self.semaphore.release()
-        ).map_err(|_|
-            io::Error::new(ErrorKind::BrokenPipe, "hwnd destroyed")
+        self.sender.send(json).map_err(|_|
+            io::Error::new(ErrorKind::BrokenPipe, "rpc rx thread lost")
         )
     }
 }
 
+// We're not using the semaphore for now, but it might come in handy at
+// some point.
+/*
 pub struct Semaphore(HANDLE);
 unsafe impl Send for Semaphore {}
 
@@ -148,3 +145,4 @@ impl Semaphore {
         self.0
     }
 }
+*/

--- a/xi-win-shell/examples/hello.rs
+++ b/xi-win-shell/examples/hello.rs
@@ -15,6 +15,7 @@
 extern crate xi_win_shell;
 extern crate direct2d;
 
+use std::any::Any;
 use std::cell::RefCell;
 
 use direct2d::math::*;
@@ -83,6 +84,8 @@ impl WinHandler for HelloState {
     fn destroy(&self) {
         win_main::request_quit();
     }
+
+    fn as_any(&self) -> &Any { self }
 }
 
 fn main() {
@@ -94,7 +97,7 @@ fn main() {
     menubar.add_dropdown(file_menu, "&File");
 
     let mut run_loop = win_main::RunLoop::new();
-    let mut builder = WindowBuilder::new(run_loop.get_handle());
+    let mut builder = WindowBuilder::new();
     builder.set_handler(Box::new(HelloState::default()));
     builder.set_title("Hello example");
     builder.set_menu(menubar);

--- a/xi-win-shell/examples/perftest.rs
+++ b/xi-win-shell/examples/perftest.rs
@@ -17,6 +17,7 @@ extern crate direct2d;
 extern crate directwrite;
 extern crate time;
 
+use std::any::Any;
 use std::cell::RefCell;
 
 use time::get_time;
@@ -119,13 +120,15 @@ impl WinHandler for PerfTest {
     fn destroy(&self) {
         win_main::request_quit();
     }
+
+    fn as_any(&self) -> &Any { self }
 }
 
 fn main() {
     xi_win_shell::init();
 
     let mut run_loop = win_main::RunLoop::new();
-    let mut builder = WindowBuilder::new(run_loop.get_handle());
+    let mut builder = WindowBuilder::new();
     let perf_state = PerfState {
         dwrite_factory: directwrite::Factory::new().unwrap(),
         handle: Default::default(),


### PR DESCRIPTION
Note: this somewhat duplicates xi_rpc, but we're going to do a
separate version because the constraints are slightly different.

Also changes threading architecture so that RPC handler has its
own thread, and uses idle scheduler to put work back on the main
runloop thread.