### PR TITLE
Prototype of ECS-based UI

### DIFF
--- a/xi-win-shell/examples/gui.rs
+++ b/xi-win-shell/examples/gui.rs
@@ -1,0 +1,344 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Sketch of entity-component based GUI.
+
+extern crate xi_win_shell;
+extern crate direct2d;
+
+use std::any::Any;
+use std::cell::RefCell;
+
+use direct2d::math::*;
+use direct2d::RenderTarget;
+use direct2d::brush::SolidColorBrush;
+
+use xi_win_shell::menu::Menu;
+use xi_win_shell::paint::PaintCtx;
+use xi_win_shell::win_main;
+use xi_win_shell::window::{MouseButton, MouseType, WindowBuilder, WindowHandle, WinHandler};
+
+#[derive(Default)]
+struct GuiMain {
+    state: RefCell<GuiState>,
+}
+
+type Id = usize;
+
+#[derive(Default)]
+struct GuiState {
+    handle: WindowHandle,
+    widgets: Vec<Box<Widget>>,
+
+    // The position in the geometry is relative to the parent.
+    geom: Vec<Geometry>,
+    graph: Graph,
+}
+
+#[derive(Default)]
+struct Graph {
+    root: Id,
+    children: Vec<Vec<Id>>,
+    parent: Vec<Id>,
+}
+
+#[derive(Default)]
+struct Geometry {
+    // Maybe PointF is a better type, then we could use the math from direct2d?
+    pos: (f32, f32),
+    size: (f32, f32),
+}
+
+struct BoxConstraints {
+    min_width: f32,
+    max_width: f32,
+    min_height: f32,
+    max_height: f32,
+}
+
+enum LayoutResult {
+    Size((f32, f32)),
+    RequestChild(Id, BoxConstraints),
+}
+
+struct LayoutCtx<'a>(&'a mut [Geometry]);
+
+trait Widget {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry);
+
+    /// `size` is the size of the child previously requested by a RequestChild return.
+    fn layout(&mut self, bc: &BoxConstraints, children: &[Id], size: Option<(f32, f32)>,
+        ctx: &mut LayoutCtx) -> LayoutResult;
+
+    /// An `escape hatch` of sorts for accessing widget state beyond the widget
+    /// methods. Returns true if it is handled.
+    fn poke(&mut self, payload: &mut Any, ctx: &mut PokeCtx) -> bool { false }
+}
+
+struct PokeCtx;
+
+struct FooWidget;
+
+#[derive(Default)]
+struct Row {
+    // layout continuation state
+    ix: usize,
+    width_per_flex: f32,
+    height: f32,
+}
+
+impl Geometry {
+    fn offset(&self, offset: (f32, f32)) -> Geometry {
+        Geometry {
+            pos: (self.pos.0 + offset.0, self.pos.1 + offset.1),
+            size: self.size
+        }
+    }
+}
+
+// Functions like this suggest a proper size newtype.
+fn add_pos(a: (f32, f32), b: (f32, f32)) -> (f32, f32) {
+    (a.0 + b.0, a.1 + b.1)
+}
+
+impl Widget for FooWidget {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
+        let rt = paint_ctx.render_target();
+        let fg = SolidColorBrush::create(rt).with_color(0xf0f0ea).build().unwrap();
+        let (x, y) = geom.pos;
+        rt.draw_line((x + 10.0, y + 50.0), (x + 90.0, y + 90.0),
+                &fg, 1.0, None);
+    }
+
+    fn layout(&mut self, _bc: &BoxConstraints, _children: &[Id], _size: Option<(f32, f32)>,
+        _ctx: &mut LayoutCtx) -> LayoutResult
+    {
+        LayoutResult::Size((100.0, 100.0))
+    }
+}
+
+impl GuiState {
+    pub fn instantiate_widget<W>(&mut self, widget: W, children: &[Id]) -> Id
+        where W: Widget + 'static
+    {
+        let id = self.graph.alloc_node();
+        self.widgets.push(Box::new(widget));
+        self.geom.push(Default::default());
+        for &child in children {
+            self.graph.append_child(id, child);
+        }
+        id
+    }
+
+    pub fn set_root(&mut self, root: Id) {
+        self.graph.root = root;
+    }
+
+    // Do pre-order traversal on graph, painting each node in turn.
+    //
+    // Implemented as a recursion, but we could use an explicit queue instead.
+    fn paint_rec(&mut self, paint_ctx: &mut PaintCtx, node: Id, pos: (f32, f32)) {
+        let geom = self.geom[node].offset(pos);
+        self.widgets[node].paint(paint_ctx, &geom);
+        // Note: we could eliminate the clone here by carrying widgets as a mut ref,
+        // and the graph as a non-mut ref.
+        for child in self.graph.children[node].clone() {
+            self.paint_rec(paint_ctx, child, geom.pos);
+        }
+    }
+
+    fn layout(&mut self, bc: &BoxConstraints, root: Id) {
+        layout_rec(&mut self.widgets, &mut self.geom, &self.graph, bc, root);
+    }
+}
+
+fn layout_rec(widgets: &mut [Box<Widget>], geom: &mut [Geometry], graph: &Graph,
+    bc: &BoxConstraints, node: Id) -> (f32, f32)
+{
+    let mut size = None;
+    loop {
+        let layout_res = widgets[node].layout(bc, &graph.children[node], size,
+            &mut LayoutCtx(geom));
+        match layout_res {
+            LayoutResult::Size(size) => {
+                geom[node].size = size;
+                return size;
+            }
+            LayoutResult::RequestChild(child, child_bc) => {
+                size = Some(layout_rec(widgets, geom, graph, &child_bc, child));
+            }
+        }
+    }
+}
+
+impl BoxConstraints {
+    pub fn tight(size: (f32, f32)) -> BoxConstraints {
+        BoxConstraints {
+            min_width: size.0,
+            max_width: size.0,
+            min_height: size.1,
+            max_height: size.1,
+        }
+    }
+}
+
+impl<'a> LayoutCtx<'a> {
+    pub fn position_child(&mut self, child: Id, pos: (f32, f32)) {
+        self.0[child].pos = pos;
+    }
+
+    pub fn get_child_size(&self, child: Id) -> (f32, f32) {
+        self.0[child].size
+    }
+}
+
+impl Widget for Row {
+    // Maybe there should be a no-op default method, for containers in general?
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {        
+    }
+
+    fn layout(&mut self, bc: &BoxConstraints, children: &[Id], size: Option<(f32, f32)>,
+        ctx: &mut LayoutCtx) -> LayoutResult
+    {
+        if let Some(size) = size {
+            if size.1 > self.height {
+                self.height = size.1;
+            }
+            self.ix += 1;
+            if self.ix == children.len() {
+                // measured all children
+                let mut x = 0.0;
+                for &child in children {
+                    // top-align, could do center etc. based on child height
+                    ctx.position_child(child, (x, 0.0));
+                    x += self.width_per_flex;
+                }
+                return LayoutResult::Size((bc.max_width, self.height));
+            }
+        } else {
+            if children.is_empty() {
+                return LayoutResult::Size((bc.min_width, bc.min_height));
+            }
+            self.ix = 0;
+            self.height = bc.min_height;
+            self.width_per_flex = bc.max_width / (children.len() as f32);
+        }
+        let child_bc = BoxConstraints {
+            min_width: self.width_per_flex,
+            max_width: self.width_per_flex,
+            min_height: bc.min_height,
+            max_height: bc.max_height,
+        };
+        LayoutResult::RequestChild(self.ix, child_bc)
+    }
+}
+
+impl WinHandler for GuiMain {
+    fn connect(&self, handle: &WindowHandle) {
+        self.state.borrow_mut().handle = handle.clone();
+    }
+
+    fn paint(&self, paint_ctx: &mut PaintCtx) -> bool {
+        let size;
+        {
+            let rt = paint_ctx.render_target();
+            size = rt.get_size();
+            let rect = RectF::from((0.0, 0.0, size.width, size.height));
+            let bg = SolidColorBrush::create(rt).with_color(0x272822).build().unwrap();
+            rt.fill_rectangle(rect, &bg);
+        }
+        let mut state = self.state.borrow_mut();
+        let root = state.graph.root;
+        let bc = BoxConstraints::tight((size.width, size.height));
+        // TODO: be lazier about relayout
+        state.layout(&bc, root);
+        state.paint_rec(paint_ctx, root, (0.0, 0.0));
+        false
+    }
+
+    fn command(&self, id: u32) {
+        match id {
+            0x100 => self.state.borrow().handle.close(),
+            _ => println!("unexpected id {}", id),
+        }
+    }
+
+    fn char(&self, ch: u32, mods: u32) {
+        println!("got char 0x{:x} {:02x}", ch, mods);
+    }
+
+    fn keydown(&self, vk_code: i32, mods: u32) -> bool {
+        println!("got key code 0x{:x} {:02x}", vk_code, mods);
+        false
+    }
+
+    fn mouse_wheel(&self, delta: i32, mods: u32) {
+        println!("mouse_wheel {} {:02x}", delta, mods);
+    }
+
+    fn mouse_hwheel(&self, delta: i32, mods: u32) {
+        println!("mouse_hwheel {} {:02x}", delta, mods);
+    }
+
+    fn mouse_move(&self, x: i32, y: i32, mods: u32) {
+        println!("mouse_move ({}, {}) {:02x}", x, y, mods);
+    }
+
+    fn mouse(&self, x: i32, y: i32, mods: u32, button: MouseButton, ty: MouseType) {
+        println!("mouse_move ({}, {}) {:02x} {:?} {:?}", x, y, mods, button, ty);
+    }
+
+    fn destroy(&self) {
+        win_main::request_quit();
+    }
+
+    fn as_any(&self) -> &Any { self }
+}
+
+fn main() {
+    xi_win_shell::init();
+
+    let mut file_menu = Menu::new();
+    file_menu.add_item(0x100, "E&xit");
+    let mut menubar = Menu::new();
+    menubar.add_dropdown(file_menu, "&File");
+
+    let mut run_loop = win_main::RunLoop::new();
+    let mut builder = WindowBuilder::new();
+    let mut state = GuiState::default();
+    let foo1 = state.instantiate_widget(FooWidget, &[]);
+    let foo2 = state.instantiate_widget(FooWidget, &[]);
+    let root = state.instantiate_widget(Row::default(), &[foo1, foo2]);
+    state.set_root(root);
+    builder.set_handler(Box::new(GuiMain { state: RefCell::new(state) }));
+    builder.set_title("Hello example");
+    builder.set_menu(menubar);
+    let window = builder.build().unwrap();
+    window.show();
+    run_loop.run();
+}
+
+impl Graph {
+    pub fn alloc_node(&mut self) -> Id {
+        let id = self.children.len();
+        self.children.push(vec![]);
+        self.parent.push(id);
+        id
+    }
+
+    pub fn append_child(&mut self, parent: Id, child: Id) {
+        self.children[parent].push(child);
+        self.parent[child] = parent;
+    }
+}

--- a/xi-win-ui/Cargo.lock
+++ b/xi-win-ui/Cargo.lock
@@ -1,0 +1,241 @@
+[[package]]
+name = "bitflags"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "boolinator"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "direct2d"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "directwrite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "directwrite"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dxgi"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "either"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "time"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wio"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "xi-win-shell"
+version = "0.1.0"
+dependencies = [
+ "direct2d 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "directwrite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "xi-win-ui"
+version = "0.1.0"
+dependencies = [
+ "direct2d 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "directwrite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xi-win-shell 0.1.0",
+]
+
+[metadata]
+"checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
+"checksum boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
+"checksum direct2d 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd0d6981ed10bd6e388083423228924c4581e7a3a6764f554e81fd33868afae"
+"checksum directwrite 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "23ce50b0074bd751d4e2e91a88180de922ffb9f032e0bffebfe0f20c5dbd2b1c"
+"checksum dxgi 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1639bbfd6765e92a40267d217a7acbac5b49320b68013f39a8e4376aa8c1e091"
+"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
+"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+"checksum num-bigint 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "81b483ea42927c463e191802e7334556b48e7875297564c0e9951bd3a0ae53e3"
+"checksum num-complex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
+"checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
+"checksum num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
+"checksum num-rational 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
+"checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
+"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
+"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8a31e8a268d6941ffb7f8d7989fc93e4692bd3e75a27d400a72b4be1dadb213"

--- a/xi-win-ui/Cargo.toml
+++ b/xi-win-ui/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "xi-win-ui"
+version = "0.1.0"
+license = "Apache-2.0"
+authors = ["Raph Levien <raph@google.com>"]
+description = "Simple Entity Component System UI toolkit layer."
+
+[dependencies]
+directwrite = "0.1.2"
+direct2d = "0.1.1"
+
+[dependencies.xi-win-shell]
+path = "../xi-win-shell"

--- a/xi-win-ui/examples/sample.rs
+++ b/xi-win-ui/examples/sample.rs
@@ -25,12 +25,13 @@ use xi_win_shell::window::WindowBuilder;
 
 use xi_win_ui::{GuiMain, GuiState};
 use xi_win_ui::{Button, FooWidget, Padding, Row};
+use xi_win_ui::COMMAND_EXIT;
 
 fn main() {
     xi_win_shell::init();
 
     let mut file_menu = Menu::new();
-    file_menu.add_item(0x100, "E&xit");
+    file_menu.add_item(COMMAND_EXIT, "E&xit");
     let mut menubar = Menu::new();
     menubar.add_dropdown(file_menu, "&File");
 

--- a/xi-win-ui/examples/sample.rs
+++ b/xi-win-ui/examples/sample.rs
@@ -19,13 +19,40 @@ extern crate xi_win_ui;
 extern crate direct2d;
 extern crate directwrite;
 
+use direct2d::brush::SolidColorBrush;
+use direct2d::RenderTarget;
+
 use xi_win_shell::menu::Menu;
+use xi_win_shell::paint::PaintCtx;
 use xi_win_shell::win_main;
 use xi_win_shell::window::WindowBuilder;
 
 use xi_win_ui::{GuiMain, GuiState};
-use xi_win_ui::{Button, FooWidget, Padding, Row};
+use xi_win_ui::widget::{Button, Row, Padding};
 use xi_win_ui::COMMAND_EXIT;
+
+use xi_win_ui::{BoxConstraints, Geometry, LayoutResult};
+use xi_win_ui::{Id, LayoutCtx};
+use xi_win_ui::widget::Widget;
+
+/// A very simple custom widget.
+pub struct FooWidget;
+
+impl Widget for FooWidget {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
+        let rt = paint_ctx.render_target();
+        let fg = SolidColorBrush::create(rt).with_color(0xf0f0ea).build().unwrap();
+        let (x, y) = geom.pos;
+        rt.draw_line((x, y), (x + geom.size.0, y + geom.size.1),
+                &fg, 1.0, None);
+    }
+
+    fn layout(&mut self, bc: &BoxConstraints, _children: &[Id], _size: Option<(f32, f32)>,
+        _ctx: &mut LayoutCtx) -> LayoutResult
+    {
+        LayoutResult::Size(bc.constrain((100.0, 100.0)))
+    }
+}
 
 fn main() {
     xi_win_shell::init();

--- a/xi-win-ui/examples/sample.rs
+++ b/xi-win-ui/examples/sample.rs
@@ -1,0 +1,60 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Sample GUI app.
+
+extern crate xi_win_shell;
+extern crate xi_win_ui;
+extern crate direct2d;
+extern crate directwrite;
+
+use xi_win_shell::menu::Menu;
+use xi_win_shell::win_main;
+use xi_win_shell::window::WindowBuilder;
+
+use xi_win_ui::{GuiMain, GuiState};
+use xi_win_ui::{Button, FooWidget, Padding, Row};
+
+fn main() {
+    xi_win_shell::init();
+
+    let mut file_menu = Menu::new();
+    file_menu.add_item(0x100, "E&xit");
+    let mut menubar = Menu::new();
+    menubar.add_dropdown(file_menu, "&File");
+
+    let mut run_loop = win_main::RunLoop::new();
+    let mut builder = WindowBuilder::new();
+    let mut state = GuiState::new();
+    let foo1 = state.add(FooWidget, &[]);
+    let foo1 = state.add(Padding::uniform(10.0), &[foo1]);
+    let foo2 = state.add(FooWidget, &[]);
+    let foo2 = state.add(Padding::uniform(10.0), &[foo2]);
+    let button = state.add(Button::new("Press me"), &[]);
+    let button2 = state.add(Button::new("Don't press me"), &[]);
+    let root = state.add(Row::default(), &[foo1, foo2, button, button2]);
+    state.set_root(root);
+    state.add_listener(button, move |_: bool, ctx| {
+        ctx.poke(button2, &mut "You clicked it!".to_string());
+    });
+    state.add_listener(button2, move |_: bool, ctx| {
+        ctx.poke(button2, &mut "Naughty naughty".to_string());
+    });
+    builder.set_handler(Box::new(GuiMain::new(state)));
+    builder.set_title("Hello example");
+    builder.set_menu(menubar);
+    let window = builder.build().unwrap();
+    window.show();
+    run_loop.run();
+}

--- a/xi-win-ui/src/lib.rs
+++ b/xi-win-ui/src/lib.rs
@@ -161,6 +161,9 @@ pub struct Button {
     label: String,
 }
 
+/// A command for exiting. TODO: move commands entirely to client.
+pub const COMMAND_EXIT: u32 = 0x100;
+
 impl Geometry {
     fn offset(&self, offset: (f32, f32)) -> Geometry {
         Geometry {

--- a/xi-win-ui/src/widget/button.rs
+++ b/xi-win-ui/src/widget/button.rs
@@ -25,7 +25,7 @@ use xi_win_shell::util::default_text_options;
 use xi_win_shell::window::{MouseButton, MouseType};
 
 use {BoxConstraints, Geometry, LayoutResult};
-use {HandlerCtx, Id, LayoutCtx, PokeCtx};
+use {HandlerCtx, Id, LayoutCtx};
 use widget::Widget;
 
 pub struct Button {
@@ -85,7 +85,7 @@ impl Widget for Button {
         true
     }
 
-    fn poke(&mut self, payload: &mut Any, ctx: &mut PokeCtx) -> bool {
+    fn poke(&mut self, payload: &mut Any, ctx: &mut HandlerCtx) -> bool {
         if let Some(string) = payload.downcast_ref::<String>() {
             self.label = string.clone();
             ctx.invalidate();

--- a/xi-win-ui/src/widget/button.rs
+++ b/xi-win-ui/src/widget/button.rs
@@ -1,0 +1,98 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A button widget
+
+use std::any::Any;
+
+use direct2d::RenderTarget;
+use direct2d::brush::SolidColorBrush;
+use directwrite::{self, TextFormat, TextLayout};
+
+use xi_win_shell::paint::PaintCtx;
+use xi_win_shell::util::default_text_options;
+use xi_win_shell::window::{MouseButton, MouseType};
+
+use {BoxConstraints, Geometry, LayoutResult};
+use {HandlerCtx, Id, LayoutCtx, PokeCtx};
+use widget::Widget;
+
+pub struct Button {
+    label: String,
+}
+
+
+impl Button {
+    pub fn new<S: Into<String>>(label: S) -> Button {
+        Button {
+            label: label.into(),
+        }
+    }
+
+    fn get_layout(&self) -> TextLayout {
+        // TODO: caching of both the format and the layout
+        // TODO: directwrite factory plumbing
+        let dwrite_factory = directwrite::Factory::new().unwrap();
+        let format = TextFormat::create(&dwrite_factory)
+            .with_family("Segoe UI")
+            .with_size(15.0)
+            .build()
+            .unwrap();
+        let layout = TextLayout::create(&dwrite_factory)
+            .with_text(&self.label)
+            .with_font(&format)
+            .with_width(1e6)
+            .with_height(1e6)
+            .build().unwrap();
+        layout
+    }
+}
+
+impl Widget for Button {
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
+        let rt = paint_ctx.render_target();
+        let fg = SolidColorBrush::create(rt).with_color(0xf0f0ea).build().unwrap();
+        let (x, y) = geom.pos;
+        let text_layout = self.get_layout();
+        rt.draw_text_layout((x, y), &text_layout, &fg, default_text_options());
+    }
+
+    fn layout(&mut self, bc: &BoxConstraints, _children: &[Id], _size: Option<(f32, f32)>,
+        _ctx: &mut LayoutCtx) -> LayoutResult
+    {
+        // TODO: need a render target plumbed down to measure text properly
+        LayoutResult::Size(bc.constrain((100.0, 17.0)))
+    }
+
+    fn mouse(&mut self, x: f32, y: f32, mods: u32, which: MouseButton, ty: MouseType,
+        ctx: &mut HandlerCtx) -> bool
+    {
+        println!("button {} {} {:x} {:?} {:?}", x, y, mods, which, ty);
+        if ty == MouseType::Down {
+            ctx.send_event(true);
+        }
+        true
+    }
+
+    fn poke(&mut self, payload: &mut Any, ctx: &mut PokeCtx) -> bool {
+        if let Some(string) = payload.downcast_ref::<String>() {
+            self.label = string.clone();
+            ctx.invalidate();
+            true
+        } else {
+            println!("downcast failed");
+            false
+        }
+    }
+}

--- a/xi-win-ui/src/widget/mod.rs
+++ b/xi-win-ui/src/widget/mod.rs
@@ -1,0 +1,61 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Widget trait and common widgets.
+
+use std::any::Any;
+
+use xi_win_shell::paint::PaintCtx;
+use xi_win_shell::window::{MouseButton, MouseType};
+
+use {BoxConstraints, Geometry, LayoutResult};
+use {HandlerCtx, Id, LayoutCtx, PokeCtx};
+
+mod button;
+pub use widget::button::Button;
+
+mod row;
+pub use widget::row::Row;
+
+mod padding;
+pub use widget::padding::Padding;
+
+/// The trait implemented by all widgets.
+pub trait Widget {
+    /// Paint the widget's appearance into the paint context.
+    ///
+    /// The implementer is responsible for translating the coordinates as
+    /// specified in the geometry.
+    #[allow(unused)]
+    fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {}
+
+    /// Participate in the layout protocol.
+    ///
+    /// `size` is the size of the child previously requested by a RequestChild return.
+    fn layout(&mut self, bc: &BoxConstraints, children: &[Id], size: Option<(f32, f32)>,
+        ctx: &mut LayoutCtx) -> LayoutResult;
+
+    /// Handle a mouse event.
+    ///
+    /// TODO: `MouseType` will be replaced by a click count.
+    #[allow(unused)]
+    fn mouse(&mut self, x: f32, y: f32, mods: u32, which: MouseButton, ty: MouseType,
+        ctx: &mut HandlerCtx) -> bool
+    { false }
+
+    /// An `escape hatch` of sorts for accessing widget state beyond the widget
+    /// methods. Returns true if it is handled.
+    #[allow(unused)]
+    fn poke(&mut self, payload: &mut Any, ctx: &mut PokeCtx) -> bool { false }
+}

--- a/xi-win-ui/src/widget/mod.rs
+++ b/xi-win-ui/src/widget/mod.rs
@@ -20,7 +20,7 @@ use xi_win_shell::paint::PaintCtx;
 use xi_win_shell::window::{MouseButton, MouseType};
 
 use {BoxConstraints, Geometry, LayoutResult};
-use {HandlerCtx, Id, LayoutCtx, PokeCtx};
+use {HandlerCtx, Id, LayoutCtx};
 
 mod button;
 pub use widget::button::Button;
@@ -57,5 +57,5 @@ pub trait Widget {
     /// An `escape hatch` of sorts for accessing widget state beyond the widget
     /// methods. Returns true if it is handled.
     #[allow(unused)]
-    fn poke(&mut self, payload: &mut Any, ctx: &mut PokeCtx) -> bool { false }
+    fn poke(&mut self, payload: &mut Any, ctx: &mut HandlerCtx) -> bool { false }
 }

--- a/xi-win-ui/src/widget/padding.rs
+++ b/xi-win-ui/src/widget/padding.rs
@@ -1,0 +1,59 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A widget that just adds padding during layout.
+
+use {BoxConstraints, LayoutResult};
+use {Id, LayoutCtx};
+use widget::Widget;
+
+/// A padding widget. Is expected to have exactly one child.
+pub struct Padding {
+    left: f32,
+    right: f32,
+    top: f32,
+    bottom: f32,
+}
+
+impl Padding {
+    /// Create widget with uniform padding.
+    pub fn uniform(padding: f32) -> Padding {
+        Padding {
+            left: padding,
+            right: padding,
+            top: padding,
+            bottom: padding,
+        }
+    }
+}
+
+impl Widget for Padding {
+    fn layout(&mut self, bc: &BoxConstraints, children: &[Id], size: Option<(f32, f32)>,
+        ctx: &mut LayoutCtx) -> LayoutResult
+    {
+        if let Some(size) = size {
+            ctx.position_child(children[0], (self.left, self.top));
+            LayoutResult::Size((size.0 + self.left + self.right,
+                size.1 + self.top + self.bottom))
+        } else {
+            let child_bc = BoxConstraints {
+                min_width: bc.min_width - (self.left + self.right),
+                max_width: bc.max_width - (self.left + self.right),
+                min_height: bc.min_height - (self.top + self.bottom),
+                max_height: bc.max_height - (self.top + self.bottom),
+            };
+            LayoutResult::RequestChild(children[0], child_bc)
+        }
+    }
+}

--- a/xi-win-ui/src/widget/row.rs
+++ b/xi-win-ui/src/widget/row.rs
@@ -1,0 +1,64 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A button widget
+
+use {BoxConstraints, LayoutResult};
+use {Id, LayoutCtx};
+use widget::Widget;
+
+#[derive(Default)]
+pub struct Row {
+    // layout continuation state
+    ix: usize,
+    width_per_flex: f32,
+    height: f32,
+}
+
+impl Widget for Row {
+    fn layout(&mut self, bc: &BoxConstraints, children: &[Id], size: Option<(f32, f32)>,
+        ctx: &mut LayoutCtx) -> LayoutResult
+    {
+        if let Some(size) = size {
+            if size.1 > self.height {
+                self.height = size.1;
+            }
+            self.ix += 1;
+            if self.ix == children.len() {
+                // measured all children
+                let mut x = 0.0;
+                for &child in children {
+                    // top-align, could do center etc. based on child height
+                    ctx.position_child(child, (x, 0.0));
+                    x += self.width_per_flex;
+                }
+                return LayoutResult::Size((bc.max_width, self.height));
+            }
+        } else {
+            if children.is_empty() {
+                return LayoutResult::Size((bc.min_width, bc.min_height));
+            }
+            self.ix = 0;
+            self.height = bc.min_height;
+            self.width_per_flex = bc.max_width / (children.len() as f32);
+        }
+        let child_bc = BoxConstraints {
+            min_width: self.width_per_flex,
+            max_width: self.width_per_flex,
+            min_height: bc.min_height,
+            max_height: bc.max_height,
+        };
+        LayoutResult::RequestChild(children[self.ix], child_bc)
+    }
+}


### PR DESCRIPTION
Creates a new xi-win-ui crate which is (presently) a prototype of a UI toolkit based on the entity-component-system architecture. We'll probably migrate the main app to this (especially because this new layer is where stuff like mouse click counting should happen), but it's experimental for now.