### PR TITLE
Refactoring and simplification of gui state

### DIFF
--- a/xi-win-ui/examples/sample.rs
+++ b/xi-win-ui/examples/sample.rs
@@ -23,7 +23,6 @@ use direct2d::brush::SolidColorBrush;
 use direct2d::RenderTarget;
 
 use xi_win_shell::menu::Menu;
-use xi_win_shell::paint::PaintCtx;
 use xi_win_shell::win_main;
 use xi_win_shell::window::WindowBuilder;
 
@@ -32,7 +31,7 @@ use xi_win_ui::widget::{Button, Row, Padding};
 use xi_win_ui::COMMAND_EXIT;
 
 use xi_win_ui::{BoxConstraints, Geometry, LayoutResult};
-use xi_win_ui::{Id, LayoutCtx};
+use xi_win_ui::{Id, LayoutCtx, PaintCtx};
 use xi_win_ui::widget::Widget;
 
 /// A very simple custom widget.

--- a/xi-win-ui/examples/sample.rs
+++ b/xi-win-ui/examples/sample.rs
@@ -31,7 +31,7 @@ use xi_win_ui::widget::{Button, Row, Padding};
 use xi_win_ui::COMMAND_EXIT;
 
 use xi_win_ui::{BoxConstraints, Geometry, LayoutResult};
-use xi_win_ui::{Id, LayoutCtx, PaintCtx};
+use xi_win_ui::{Id, LayoutCtx, ListenerCtx, PaintCtx};
 use xi_win_ui::widget::Widget;
 
 /// A very simple custom widget.
@@ -53,6 +53,12 @@ impl Widget for FooWidget {
     }
 }
 
+impl FooWidget {
+    fn bind(self, ctx: &mut ListenerCtx) -> Id {
+        ctx.add(self, &[])
+    }
+}
+
 fn main() {
     xi_win_shell::init();
 
@@ -64,13 +70,13 @@ fn main() {
     let mut run_loop = win_main::RunLoop::new();
     let mut builder = WindowBuilder::new();
     let mut state = GuiState::new();
-    let foo1 = state.add(FooWidget, &[]);
-    let foo1 = state.add(Padding::uniform(10.0), &[foo1]);
-    let foo2 = state.add(FooWidget, &[]);
-    let foo2 = state.add(Padding::uniform(10.0), &[foo2]);
-    let button = state.add(Button::new("Press me"), &[]);
-    let button2 = state.add(Button::new("Don't press me"), &[]);
-    let root = state.add(Row::default(), &[foo1, foo2, button, button2]);
+    let foo1 = FooWidget.bind(&mut state);
+    let foo1 = Padding::uniform(10.0).bind(foo1, &mut state);
+    let foo2 = FooWidget.bind(&mut state);
+    let foo2 = Padding::uniform(10.0).bind(foo2, &mut state);
+    let button = Button::new("Press me").bind(&mut state);
+    let button2 = Button::new("Don't press me").bind(&mut state);
+    let root = Row::default().bind(&[foo1, foo2, button, button2], &mut state);
     state.set_root(root);
     state.add_listener(button, move |_: bool, ctx| {
         ctx.poke(button2, &mut "You clicked it!".to_string());

--- a/xi-win-ui/src/lib.rs
+++ b/xi-win-ui/src/lib.rs
@@ -45,25 +45,33 @@ pub struct GuiMain {
 pub type Id = usize;
 
 pub struct GuiState {
+    listeners: BTreeMap<Id, Vec<Box<FnMut(&Any, &mut ListenerCtx)>>>,
+
+    b: ListenerCtx,
+}
+
+pub struct ListenerCtx {
+    /// The individual widget trait objects.
+    widgets: Vec<Box<Widget>>,
+
+    /// Graph of widgets (actually a strict tree structure, so maybe should be renamed).
+    graph: Graph,
+
+    c: LayoutCtx,
+}
+
+pub struct LayoutCtx {
     // TODO: plumbing
     #[allow(unused)]
     dwrite_factory: directwrite::Factory,
 
     handle: WindowHandle,
 
-    /// The individual widget trait objects.
-    widgets: Vec<Box<Widget>>,
-
     /// Bounding box of each widget. The position is relative to the parent.
     geom: Vec<Geometry>,
 
-    /// Graph of widgets (actually a strict tree structure, so maybe should be renamed).
-    graph: Graph,
-
     /// Queue of events to distribute to listeners
     event_q: Vec<(Id, Box<Any>)>,
-
-    listeners: BTreeMap<Id, Vec<Box<FnMut(&Any, &mut ListenerCtx)>>>,
 }
 
 #[derive(Default)]
@@ -73,7 +81,7 @@ struct Graph {
     parent: Vec<Id>,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct Geometry {
     // Maybe PointF is a better type, then we could use the math from direct2d?
     pub pos: (f32, f32),
@@ -94,39 +102,12 @@ pub enum LayoutResult {
 
 // Contexts for widget methods.
 
-/// Context given to layout methods.
-///
-/// TODO: plumb directwrite factory.
-pub struct LayoutCtx<'a>(&'a mut [Geometry]);
-
 /// Context given to handlers.
 pub struct HandlerCtx<'a> {
     /// The id of the node sending the event
     id: Id,
 
-    /// Reference for event queue, for sending events to listeners.
-    event_q: &'a mut Vec<(Id, Box<Any>)>,
-
-    /// For invalidation.
-    handle: &'a WindowHandle,
-}
-
-/// Context given to listeners, allowing responsive update to the GUI.
-///
-/// Currently mostly for "poke" actions, but we also want to allow reconfiguration
-/// of the widget graph, etc. Probably want to have a single unified interface for
-/// graph manipulations.
-pub struct ListenerCtx<'a> {
-    widgets: &'a mut [Box<Widget>],
-
-    // The next 2 fields are not directly used by listeners, but passed
-    // through to handler context (on "poke").
-
-    /// Reference for event queue, for sending events to listeners.
-    event_q: &'a mut Vec<(Id, Box<Any>)>,
-
-    /// For invalidation.
-    handle: &'a WindowHandle,
+    c: &'a mut LayoutCtx,
 }
 
 /// A command for exiting. TODO: move commands entirely to client.
@@ -150,13 +131,17 @@ impl GuiMain {
 impl GuiState {
     pub fn new() -> GuiState {
         GuiState {
-            dwrite_factory: directwrite::Factory::new().unwrap(),
-            widgets: Vec::new(),
-            geom: Vec::new(),
-            handle: Default::default(),
-            graph: Default::default(),
-            event_q: Vec::new(),
             listeners: Default::default(),
+            b: ListenerCtx {
+                widgets: Vec::new(),
+                graph: Default::default(),
+                c: LayoutCtx {
+                    dwrite_factory: directwrite::Factory::new().unwrap(),
+                    geom: Vec::new(),
+                    handle: Default::default(),
+                    event_q: Vec::new(),
+                }
+            }
         }
     }
 
@@ -165,17 +150,17 @@ impl GuiState {
     pub fn add<W>(&mut self, widget: W, children: &[Id]) -> Id
         where W: Widget + 'static
     {
-        let id = self.graph.alloc_node();
-        self.widgets.push(Box::new(widget));
-        self.geom.push(Default::default());
+        let id = self.b.graph.alloc_node();
+        self.b.widgets.push(Box::new(widget));
+        self.b.c.geom.push(Default::default());
         for &child in children {
-            self.graph.append_child(id, child);
+            self.b.graph.append_child(id, child);
         }
         id
     }
 
     pub fn set_root(&mut self, root: Id) {
-        self.graph.root = root;
+        self.b.graph.root = root;
     }
 
     /// Add a listener that expects a specific type.
@@ -196,61 +181,55 @@ impl GuiState {
     //
     // Implemented as a recursion, but we could use an explicit queue instead.
     fn paint_rec(&mut self, paint_ctx: &mut PaintCtx, node: Id, pos: (f32, f32)) {
-        let geom = self.geom[node].offset(pos);
-        self.widgets[node].paint(paint_ctx, &geom);
+        let geom = self.b.c.geom[node].offset(pos);
+        self.b.widgets[node].paint(paint_ctx, &geom);
         // Note: we could eliminate the clone here by carrying widgets as a mut ref,
         // and the graph as a non-mut ref.
-        for child in self.graph.children[node].clone() {
+        for child in self.b.graph.children[node].clone() {
             self.paint_rec(paint_ctx, child, geom.pos);
         }
     }
 
     fn layout(&mut self, bc: &BoxConstraints, root: Id) {
-        layout_rec(&mut self.widgets, &mut self.geom, &self.graph, bc, root);
+        layout_rec(&mut self.b.widgets, &mut self.b.c, &self.b.graph, bc, root);
     }
 
     fn mouse(&mut self, x: f32, y: f32, mods: u32, which: MouseButton, ty: MouseType) {
-        mouse_rec(&mut self.widgets, &self.geom, &self.graph,
+        mouse_rec(&mut self.b.widgets, &self.b.graph,
             x, y, mods, which, ty,
             &mut HandlerCtx {
-                id: self.graph.root,
-                event_q: &mut self.event_q,
-                handle: &self.handle,
+                id: self.b.graph.root,
+                c: &mut self.b.c,
             }
         );
         self.dispatch_events();
     }
 
     fn dispatch_events(&mut self) {
-        let event_q = mem::replace(&mut self.event_q, Vec::new());
+        let event_q = mem::replace(&mut self.b.c.event_q, Vec::new());
         for (id, event) in event_q {
             if let Some(listeners) = self.listeners.get_mut(&id) {
                 for listener in listeners {
-                    let mut ctx = ListenerCtx {
-                        handle: &self.handle,
-                        event_q: &mut self.event_q,
-                        widgets: &mut self.widgets,
-                    };
+                    let mut ctx = &mut self.b;
                     listener(event.deref(), &mut ctx);
                 }
             }
         }
     }
 }
-fn layout_rec(widgets: &mut [Box<Widget>], geom: &mut [Geometry], graph: &Graph,
+fn layout_rec(widgets: &mut [Box<Widget>], ctx: &mut LayoutCtx, graph: &Graph,
     bc: &BoxConstraints, node: Id) -> (f32, f32)
 {
     let mut size = None;
     loop {
-        let layout_res = widgets[node].layout(bc, &graph.children[node], size,
-            &mut LayoutCtx(geom));
+        let layout_res = widgets[node].layout(bc, &graph.children[node], size, ctx);
         match layout_res {
             LayoutResult::Size(size) => {
-                geom[node].size = size;
+                ctx.geom[node].size = size;
                 return size;
             }
             LayoutResult::RequestChild(child, child_bc) => {
-                size = Some(layout_rec(widgets, geom, graph, &child_bc, child));
+                size = Some(layout_rec(widgets, ctx, graph, &child_bc, child));
             }
         }
     }
@@ -282,22 +261,22 @@ impl BoxConstraints {
     }
 }
 
-impl<'a> LayoutCtx<'a> {
+impl LayoutCtx {
     pub fn position_child(&mut self, child: Id, pos: (f32, f32)) {
-        self.0[child].pos = pos;
+        self.geom[child].pos = pos;
     }
 
     pub fn get_child_size(&self, child: Id) -> (f32, f32) {
-        self.0[child].size
+        self.geom[child].size
     }
 }
 
-fn mouse_rec(widgets: &mut [Box<Widget>], geom: &[Geometry], graph: &Graph,
+fn mouse_rec(widgets: &mut [Box<Widget>], graph: &Graph,
     x: f32, y: f32, mods: u32, which: MouseButton, ty: MouseType, ctx: &mut HandlerCtx)
     -> bool
 {
     let node = ctx.id;
-    let g = &geom[node];
+    let g = ctx.c.geom[node];
     let x = x - g.pos.0;
     let y = y - g.pos.1;
     let mut handled = false;
@@ -308,34 +287,31 @@ fn mouse_rec(widgets: &mut [Box<Widget>], geom: &[Geometry], graph: &Graph,
                 break;
             }
             ctx.id = *child;
-            handled = mouse_rec(widgets, geom, graph, x, y, mods, which, ty, ctx);
+            handled = mouse_rec(widgets, graph, x, y, mods, which, ty, ctx);
         }
     }
     handled
 }
 
-// TODO: we're going to want a common set of invalidation methods; should we
-// have a trait?
 impl<'a> HandlerCtx<'a> {
     pub fn invalidate(&self) {
-        self.handle.invalidate();
+        self.c.handle.invalidate();
     }
 
     // Send an event, to be handled by listeners.
     pub fn send_event<A: Any>(&mut self, a: A) {
         let id = self.id;
-        self.event_q.push((id, Box::new(a)));
+        self.c.event_q.push((id, Box::new(a)));
     }
 }
 
-impl<'a> ListenerCtx<'a> {
+impl ListenerCtx {
     /// Send an arbitrary payload to a widget. The type and interpretation of the
     /// payload depends on the specific target widget.
     pub fn poke<A: Any>(&mut self, node: Id, payload: &mut A) -> bool {
         let mut ctx = HandlerCtx {
             id: node,
-            handle: self.handle,
-            event_q: self.event_q,
+            c: &mut self.c,
         };
         self.widgets[node].poke(payload, &mut ctx)
     }
@@ -343,7 +319,7 @@ impl<'a> ListenerCtx<'a> {
 
 impl WinHandler for GuiMain {
     fn connect(&self, handle: &WindowHandle) {
-        self.state.borrow_mut().handle = handle.clone();
+        self.state.borrow_mut().b.c.handle = handle.clone();
     }
 
     fn paint(&self, paint_ctx: &mut PaintCtx) -> bool {
@@ -356,7 +332,7 @@ impl WinHandler for GuiMain {
             rt.fill_rectangle(rect, &bg);
         }
         let mut state = self.state.borrow_mut();
-        let root = state.graph.root;
+        let root = state.b.graph.root;
         let bc = BoxConstraints::tight((size.width, size.height));
         // TODO: be lazier about relayout
         state.layout(&bc, root);
@@ -367,7 +343,7 @@ impl WinHandler for GuiMain {
     fn command(&self, id: u32) {
         // TODO: plumb through to client
         match id {
-            COMMAND_EXIT => self.state.borrow().handle.close(),
+            COMMAND_EXIT => self.state.borrow().b.c.handle.close(),
             _ => println!("unexpected id {}", id),
         }
     }
@@ -396,7 +372,7 @@ impl WinHandler for GuiMain {
     fn mouse(&self, x: i32, y: i32, mods: u32, button: MouseButton, ty: MouseType) {
         println!("mouse ({}, {}) {:02x} {:?} {:?}", x, y, mods, button, ty);
         let mut state = self.state.borrow_mut();
-        let (x, y) = state.handle.pixels_to_px_xy(x, y);
+        let (x, y) = state.b.c.handle.pixels_to_px_xy(x, y);
         // TODO: detect multiple clicks and pass that down
         state.mouse(x, y, mods, button, ty);
     }

--- a/xi-win-ui/src/widget/button.rs
+++ b/xi-win-ui/src/widget/button.rs
@@ -24,7 +24,7 @@ use xi_win_shell::util::default_text_options;
 use xi_win_shell::window::{MouseButton, MouseType};
 
 use {BoxConstraints, Geometry, LayoutResult};
-use {HandlerCtx, Id, LayoutCtx, PaintCtx};
+use {HandlerCtx, Id, LayoutCtx, ListenerCtx, PaintCtx};
 use widget::Widget;
 
 pub struct Button {
@@ -37,6 +37,10 @@ impl Button {
         Button {
             label: label.into(),
         }
+    }
+
+    pub fn bind(self, ctx: &mut ListenerCtx) -> Id {
+        ctx.add(self, &[])
     }
 
     fn get_layout(&self, dwrite_factory: &directwrite::Factory) -> TextLayout {

--- a/xi-win-ui/src/widget/button.rs
+++ b/xi-win-ui/src/widget/button.rs
@@ -20,12 +20,11 @@ use direct2d::RenderTarget;
 use direct2d::brush::SolidColorBrush;
 use directwrite::{self, TextFormat, TextLayout};
 
-use xi_win_shell::paint::PaintCtx;
 use xi_win_shell::util::default_text_options;
 use xi_win_shell::window::{MouseButton, MouseType};
 
 use {BoxConstraints, Geometry, LayoutResult};
-use {HandlerCtx, Id, LayoutCtx};
+use {HandlerCtx, Id, LayoutCtx, PaintCtx};
 use widget::Widget;
 
 pub struct Button {
@@ -40,10 +39,8 @@ impl Button {
         }
     }
 
-    fn get_layout(&self) -> TextLayout {
+    fn get_layout(&self, dwrite_factory: &directwrite::Factory) -> TextLayout {
         // TODO: caching of both the format and the layout
-        // TODO: directwrite factory plumbing
-        let dwrite_factory = directwrite::Factory::new().unwrap();
         let format = TextFormat::create(&dwrite_factory)
             .with_family("Segoe UI")
             .with_size(15.0)
@@ -61,10 +58,10 @@ impl Button {
 
 impl Widget for Button {
     fn paint(&mut self, paint_ctx: &mut PaintCtx, geom: &Geometry) {
+        let text_layout = self.get_layout(paint_ctx.dwrite_factory());
         let rt = paint_ctx.render_target();
         let fg = SolidColorBrush::create(rt).with_color(0xf0f0ea).build().unwrap();
         let (x, y) = geom.pos;
-        let text_layout = self.get_layout();
         rt.draw_text_layout((x, y), &text_layout, &fg, default_text_options());
     }
 

--- a/xi-win-ui/src/widget/mod.rs
+++ b/xi-win-ui/src/widget/mod.rs
@@ -16,11 +16,10 @@
 
 use std::any::Any;
 
-use xi_win_shell::paint::PaintCtx;
 use xi_win_shell::window::{MouseButton, MouseType};
 
 use {BoxConstraints, Geometry, LayoutResult};
-use {HandlerCtx, Id, LayoutCtx};
+use {HandlerCtx, Id, LayoutCtx, PaintCtx};
 
 mod button;
 pub use widget::button::Button;

--- a/xi-win-ui/src/widget/padding.rs
+++ b/xi-win-ui/src/widget/padding.rs
@@ -15,7 +15,7 @@
 //! A widget that just adds padding during layout.
 
 use {BoxConstraints, LayoutResult};
-use {Id, LayoutCtx};
+use {Id, LayoutCtx, ListenerCtx};
 use widget::Widget;
 
 /// A padding widget. Is expected to have exactly one child.
@@ -35,6 +35,10 @@ impl Padding {
             top: padding,
             bottom: padding,
         }
+    }
+
+    pub fn bind(self, child: Id, ctx: &mut ListenerCtx) -> Id {
+        ctx.add(self, &[child])
     }
 }
 

--- a/xi-win-ui/src/widget/row.rs
+++ b/xi-win-ui/src/widget/row.rs
@@ -15,7 +15,7 @@
 //! A button widget
 
 use {BoxConstraints, LayoutResult};
-use {Id, LayoutCtx};
+use {Id, LayoutCtx, ListenerCtx};
 use widget::Widget;
 
 #[derive(Default)]
@@ -24,6 +24,12 @@ pub struct Row {
     ix: usize,
     width_per_flex: f32,
     height: f32,
+}
+
+impl Row {
+    pub fn bind(self, children: &[Id], ctx: &mut ListenerCtx) -> Id {
+        ctx.add(self, children)
+    }
 }
 
 impl Widget for Row {


### PR DESCRIPTION
Reorganize the GuiState structure so that contexts can be (mostly) direct references into the struct rather than another layer of indirection. Use "bind" pattern (adapted from Conrod) to assemble widgets into graph.