### PR TITLE
Bubble poke actions up the hierarchy

### DIFF
--- a/xi-win-ui/src/widget/button.rs
+++ b/xi-win-ui/src/widget/button.rs
@@ -24,7 +24,7 @@ use xi_win_shell::util::default_text_options;
 use xi_win_shell::window::{MouseButton, MouseType};
 
 use {BoxConstraints, Geometry, LayoutResult};
-use {HandlerCtx, Id, LayoutCtx, ListenerCtx, PaintCtx};
+use {HandlerCtx, Id, LayoutCtx, UiInner, PaintCtx};
 use widget::Widget;
 
 /// A text label with no interaction.
@@ -44,7 +44,7 @@ impl Label {
         }
     }
 
-    pub fn bind(self, ctx: &mut ListenerCtx) -> Id {
+    pub fn ui(self, ctx: &mut UiInner) -> Id {
         ctx.add(self, &[])
     }
 
@@ -110,7 +110,7 @@ impl Button {
         }
     }
 
-    pub fn bind(self, ctx: &mut ListenerCtx) -> Id {
+    pub fn ui(self, ctx: &mut UiInner) -> Id {
         ctx.add(self, &[])
     }
 }

--- a/xi-win-ui/src/widget/flex.rs
+++ b/xi-win-ui/src/widget/flex.rs
@@ -15,7 +15,7 @@
 //! A widget that arranges its children in a one-dimensional array.
 
 use {BoxConstraints, LayoutResult};
-use {Id, LayoutCtx, ListenerCtx};
+use {Id, LayoutCtx, UiInner};
 use widget::Widget;
 
 pub struct Row;
@@ -83,7 +83,7 @@ impl Column {
 }
 
 impl Flex {
-    pub fn bind(self, children: &[Id], ctx: &mut ListenerCtx) -> Id {
+    pub fn ui(self, children: &[Id], ctx: &mut UiInner) -> Id {
         ctx.add(self, children)
     }
 }

--- a/xi-win-ui/src/widget/mod.rs
+++ b/xi-win-ui/src/widget/mod.rs
@@ -42,8 +42,21 @@ pub trait Widget {
     /// Participate in the layout protocol.
     ///
     /// `size` is the size of the child previously requested by a RequestChild return.
+    ///
+    /// The default implementation is suitable for widgets with a single child, and
+    /// just forwards the layout unmodified.
     fn layout(&mut self, bc: &BoxConstraints, children: &[Id], size: Option<(f32, f32)>,
-        ctx: &mut LayoutCtx) -> LayoutResult;
+        ctx: &mut LayoutCtx) -> LayoutResult
+    {
+        if let Some(size) = size {
+            // Maybe this is not necessary, rely on default value.
+            ctx.position_child(children[0], (0.0, 0.0));
+            LayoutResult::Size(size)
+        } else {
+            LayoutResult::RequestChild(children[0], *bc)
+        }
+    }
+
 
     /// Handle a mouse event.
     ///

--- a/xi-win-ui/src/widget/padding.rs
+++ b/xi-win-ui/src/widget/padding.rs
@@ -15,7 +15,7 @@
 //! A widget that just adds padding during layout.
 
 use {BoxConstraints, LayoutResult};
-use {Id, LayoutCtx, ListenerCtx};
+use {Id, LayoutCtx, UiInner};
 use widget::Widget;
 
 /// A padding widget. Is expected to have exactly one child.
@@ -37,7 +37,7 @@ impl Padding {
         }
     }
 
-    pub fn bind(self, child: Id, ctx: &mut ListenerCtx) -> Id {
+    pub fn ui(self, child: Id, ctx: &mut UiInner) -> Id {
         ctx.add(self, &[child])
     }
 }


### PR DESCRIPTION
Add a "poke_up" method from listeners. Also does a bit of rename and
refactor of contexts.

This change facilitates storing generic state in the tree, but the
samples aren't changed to make use of it.